### PR TITLE
Fractions.Tests: fix invalid characters in test names

### DIFF
--- a/tests/Fractions.Tests/Catch.cs
+++ b/tests/Fractions.Tests/Catch.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 
-namespace Fractions.Tests {
-    public static class Catch {
-        public static Exception Exception(Action action) {
-            try {
-                action();
-            } catch (Exception ex) {
-                return ex;
-            }
+namespace Fractions.Tests;
 
-            return null;
+public static class Catch {
+    public static Exception Exception(Action action) {
+        try {
+            action();
+        } catch (Exception ex) {
+            return ex;
         }
+
+        return null;
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Abs/Method_Abs.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Abs/Method_Abs.cs
@@ -1,28 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Abs {
-    [Serializable]
-    internal class TestClass { }
+namespace Fractions.Tests.FractionSpecs.Abs;
 
-    [TestFixture]
-    public class If_the_Abs_function_is_called : Spec {
-        private static IEnumerable<TestCaseData> TestCases {
-            get {
-                yield return new TestCaseData(Fraction.Zero).Returns(Fraction.Zero);
-                yield return new TestCaseData(Fraction.One).Returns(Fraction.One);
-                yield return new TestCaseData(Fraction.MinusOne).Returns(Fraction.One);
-                yield return new TestCaseData(new Fraction(-1, 3)).Returns(new Fraction(1, 3));
-                yield return new TestCaseData(new Fraction(1, -3, false)).Returns(new Fraction(1, 3, false));
-                yield return new TestCaseData(new Fraction(-1, -3, false)).Returns(new Fraction(1, 3, false));
-            }
+[TestFixture]
+public class When_the_Abs_function_is_called : Spec {
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(Fraction.Zero).Returns(Fraction.Zero);
+            yield return new TestCaseData(Fraction.One).Returns(Fraction.One);
+            yield return new TestCaseData(Fraction.MinusOne).Returns(Fraction.One);
+            yield return new TestCaseData(new Fraction(-1, 3)).Returns(new Fraction(1, 3));
+            yield return new TestCaseData(new Fraction(1, -3, false)).Returns(new Fraction(1, 3));
+            yield return new TestCaseData(new Fraction(-1, -3, false)).Returns(new Fraction(1, 3));
         }
+    }
 
-        [Test, TestCaseSource(nameof(TestCases))]
-        public Fraction Shall_the_returning_fraction_be_positive(Fraction fraction) {
-            return fraction.Abs();
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public Fraction The_returning_fraction_should_be_positive(Fraction fraction) {
+        return fraction.Abs();
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Add/Method_Add.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Add/Method_Add.cs
@@ -3,26 +3,26 @@ using System.Numerics;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Add {
-    
-    [TestFixture]
-    public class If_the_user_adds_two_fractions : Spec {
-        private static IEnumerable<TestCaseData> TestCases {
-            get {
-                yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(Fraction.Zero);
-                yield return new TestCaseData(new Fraction(1L, 5L), new Fraction(1L, 4L)).Returns(new Fraction(9L, 20L));
-                yield return new TestCaseData(new Fraction(1L, 5L), Fraction.Zero).Returns(new Fraction(1L, 5L));
-                yield return new TestCaseData(Fraction.Zero, new Fraction(1L, 5L)).Returns(new Fraction(1L, 5L));
-                yield return new TestCaseData(new Fraction(1, long.MaxValue), new Fraction(1, long.MaxValue - 1)).Returns(new Fraction(
-                    BigInteger.Parse("18446744073709551613"),
-                    BigInteger.Parse("85070591730234615838173535747377725442")
-                    ));
-            }
+namespace Fractions.Tests.FractionSpecs.Add;
+
+[TestFixture]
+public class When_the_user_adds_two_fractions : Spec {
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(Fraction.Zero);
+            yield return new TestCaseData(new Fraction(1L, 5L), new Fraction(1L, 4L)).Returns(new Fraction(9L, 20L));
+            yield return new TestCaseData(new Fraction(1L, 5L), Fraction.Zero).Returns(new Fraction(1L, 5L));
+            yield return new TestCaseData(Fraction.Zero, new Fraction(1L, 5L)).Returns(new Fraction(1L, 5L));
+            yield return new TestCaseData(new Fraction(1, long.MaxValue), new Fraction(1, long.MaxValue - 1)).Returns(new Fraction(
+                BigInteger.Parse("18446744073709551613"),
+                BigInteger.Parse("85070591730234615838173535747377725442")
+            ));
         }
-        
-        [Test,TestCaseSource(nameof(TestCases))]
-        public Fraction Shall_it_return_the_expected_result(Fraction a, Fraction b) {
-            return a.Add(b);
-        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public Fraction It_should_return_the_expected_result(Fraction a, Fraction b) {
+        return a.Add(b);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/CompareTo/Method_CompareTo.cs
+++ b/tests/Fractions.Tests/FractionSpecs/CompareTo/Method_CompareTo.cs
@@ -1,28 +1,28 @@
 ﻿using System.Collections.Generic;
-using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.CompareTo {
-    [TestFixture]
-    public class When_comparing_to_fractions : Spec {
-        private static IEnumerable<TestCaseData> TestCases {
-            get {
-                yield return new TestCaseData(new Fraction(5), new Fraction(4)).Returns(1);
-                yield return new TestCaseData(new Fraction(4), new Fraction(5)).Returns(-1);
-                yield return new TestCaseData(new Fraction(5), new Fraction(5)).Returns(0);
-                yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(0);
-                yield return new TestCaseData(new Fraction(1,5), new Fraction(1,10)).Returns(1);
-                yield return new TestCaseData(new Fraction(0), new Fraction(131)).Returns(-1);
-                yield return new TestCaseData(new Fraction(-1), new Fraction(-1)).Returns(0);
-                yield return new TestCaseData(new Fraction(-1), new Fraction(0)).Returns(-1);
-                yield return new TestCaseData(new Fraction(0), new Fraction(-1)).Returns(1);
-            }
-        }
+namespace Fractions.Tests.FractionSpecs.CompareTo;
 
-        [Test,TestCaseSource(nameof(TestCases))]
-        public int Shall_the_method_CompareTo_return_the_expected_result(Fraction a, Fraction b) {
-            return a.CompareTo(b);
+[TestFixture]
+public class When_comparing_two_fractions : Spec {
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(new Fraction(5), new Fraction(4)).Returns(1);
+            yield return new TestCaseData(new Fraction(4), new Fraction(5)).Returns(-1);
+            yield return new TestCaseData(new Fraction(5), new Fraction(5)).Returns(0);
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(0);
+            yield return new TestCaseData(new Fraction(1, 5), new Fraction(1, 10)).Returns(1);
+            yield return new TestCaseData(new Fraction(0), new Fraction(131)).Returns(-1);
+            yield return new TestCaseData(new Fraction(-1), new Fraction(-1)).Returns(0);
+            yield return new TestCaseData(new Fraction(-1), new Fraction(0)).Returns(-1);
+            yield return new TestCaseData(new Fraction(0), new Fraction(-1)).Returns(1);
         }
     }
- }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public int The_CompareTo_method_should_return_the_expected_result(Fraction a, Fraction b) {
+        return a.CompareTo(b);
+    }
+}

--- a/tests/Fractions.Tests/FractionSpecs/Constructores/Constructors.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Constructores/Constructors.cs
@@ -3,321 +3,344 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Constructores {
-    [TestFixture]
-    public class If_the_user_creates_a_fraction_with_constructor_parameters : Spec {
-        private Fraction _fraction;
+namespace Fractions.Tests.FractionSpecs.Constructores;
 
-        public override void Act() {
-            _fraction = new Fraction();
-        }
+[TestFixture]
+public class If_the_user_creates_a_fraction_with_constructor_parameters : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Shall_the_numerator_be_0() {
-            _fraction.Numerator
-                .Should()
-                .Be(0);
-        }
-
-        [Test]
-        public void Shall_the_denominator_be_0() {
-            _fraction.Denominator
-                .Should()
-                .Be(0);
-        }
-
-        [Test]
-        public void Shall_the_result_indicate_that_it_IsZero() {
-            _fraction.IsZero
-                .Should()
-                .BeTrue();
-        }
+    public override void Act() {
+        _fraction = new Fraction();
     }
 
-    [TestFixture]
-    public class If_the_user_creates_a_fraction_using_0L_as_numerator_and_0L_as_denominator : Spec {
-        private Fraction _fraction;
-
-        public override void Act() {
-            _fraction = new Fraction(0L, 0L, false);
-        }
-
-        [Test]
-        public void Shall_the_result_be_Zero() {
-            _fraction.IsZero
-                .Should()
-                .BeTrue();
-        }
+    [Test]
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator
+            .Should()
+            .Be(0);
     }
 
-    [TestFixture]
-    public class If_the_user_creates_a_non_normalized_fraction_using_0L_as_numerator_and_1L_as_denominator : Spec {
-        private Fraction _fraction;
-
-        public override void Act() {
-            _fraction = new Fraction(0L, 1L, false);
-        }
-
-        [Test]
-        public void Shall_the_numerator_be_0() {
-            _fraction.Numerator
-                .Should()
-                .Be(0);
-        }
-
-        [Test]
-        public void Shall_the_denominator_be_1() {
-            _fraction.Denominator
-                .Should()
-                .Be(1);
-        }
+    [Test]
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator
+            .Should()
+            .Be(0);
     }
 
-    [TestFixture]
-    public class If_the_user_creates_a_normalized_fraction_using_0L_as_numerator_and_1L_as_denominator : Spec {
-        private Fraction _fraction;
+    [Test]
+    public void Resulting_fraction_should_be_zero() {
+        _fraction.IsZero
+            .Should()
+            .BeTrue();
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction(0L, 0L, true);
-        }
+[TestFixture]
+public class If_the_user_creates_a_fraction_using_0L_as_numerator_and_0L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Shall_the_result_be_Zero() {
-            _fraction.IsZero
-                .Should()
-                .BeTrue();
-        }
+    public override void Act() {
+        _fraction = new Fraction(0L, 0L, false);
     }
 
-    [TestFixture]
-    public class If_the_user_creates_a_normalized_fraction_using_4L_as_numerator_and_4L_as_denominator : Spec {
-        private Fraction _fraction;
+    [Test]
+    public void Resulting_fraction_should_be_zero() {
+        _fraction.IsZero
+            .Should()
+            .BeTrue();
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction(4L, 4L, true);
-        }
+[TestFixture]
+public class If_the_user_creates_a_non_normalized_fraction_using_0L_as_numerator_and_1L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Shall_the_numerator_be_1() {
-            _fraction.Numerator
-                .Should()
-                .Be(1);
-        }
-
-        [Test]
-        public void Shall_the_denominator_be_1() {
-            _fraction.Denominator
-                .Should()
-                .Be(1);
-        }
+    public override void Act() {
+        _fraction = new Fraction(0L, 1L, false);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_4L_als_Zähler_und_12L_als_Nenner_normalisiert_erzeugt_wird_dann : Spec {
-        private Fraction _fraction;
-
-        public override void Act() {
-            _fraction = new Fraction(4L, 12L, true);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_im_Zähler_1L_haben() {
-            _fraction.Numerator
-                .Should()
-                .Be(1L);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_im_Nenner_3L_haben() {
-            _fraction.Denominator
-                .Should()
-                .Be(3L);
-        }
+    [Test]
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator
+            .Should()
+            .Be(0);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_12L_als_Zähler_und_4L_als_Nenner_normalisiert_erzeugt_wird_dann : Spec {
-        private Fraction _fraction;
+    [Test]
+    public void Resulting_fraction_should_have_1_as_denominator() {
+        _fraction.Denominator
+            .Should()
+            .Be(1);
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction(12L, 4L, true);
-        }
+[TestFixture]
+public class If_the_user_creates_a_normalized_fraction_using_0L_as_numerator_and_1L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_im_Zähler_3L_haben() {
-            _fraction.Numerator
-                .Should()
-                .Be(3L);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_im_Nenner_1L_haben() {
-            _fraction.Denominator
-                .Should()
-                .Be(1L);
-        }
+    public override void Act() {
+        _fraction = new Fraction(0L, 0L, true);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_0L_als_Zähler_und_4L_als_Nenner_normalisiert_erzeugt_wird_dann : Spec {
-        private Fraction _fraction;
+    [Test]
+    public void Resulting_fraction_should_be_zero() {
+        _fraction.IsZero
+            .Should()
+            .BeTrue();
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction(0L, 4L, true);
-        }
+[TestFixture]
+public class If_the_user_creates_a_normalized_fraction_using_4L_as_numerator_and_4L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_im_Zähler_0L_haben() {
-            _fraction.Numerator
-                .Should()
-                .Be(0L);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_im_Nenner_0L_haben() {
-            _fraction.Denominator
-                .Should()
-                .Be(0L);
-        }
+    public override void Act() {
+        _fraction = new Fraction(4L, 4L, true);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_int_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void Act() {
-            _fraction = new Fraction(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
-
+    [Test]
+    public void Resulting_fraction_should_have_1_as_numerator() {
+        _fraction.Numerator
+            .Should()
+            .Be(1);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_uint_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    public void Resulting_fraction_should_have_1_as_denominator() {
+        _fraction.Denominator
+            .Should()
+            .Be(1);
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction((uint) 0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit 4L als Zähler und 12L als Nenner normalisiert erzeugt wird dann
+public class When_fraction_is_created_normalized_with_4L_as_numerator_and_12L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
-
+    public override void Act() {
+        _fraction = new Fraction(4L, 12L, true);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_long_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void Act() {
-            _fraction = new Fraction((long) 0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
-
+    [Test]
+    // German: Soll der resultierende Bruch im Zähler 1L haben
+    public void Resulting_fraction_should_have_1L_in_numerator() {
+        _fraction.Numerator
+            .Should()
+            .Be(1L);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_ulong_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der resultierende Bruch im Nenner 3L haben
+    public void Resulting_fraction_should_have_3L_in_denominator() {
+        _fraction.Denominator
+            .Should()
+            .Be(3L);
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction((ulong) 0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit 12L als Zähler und 4L als Nenner normalisiert erzeugt wird dann
+public class When_fraction_is_created_normalized_with_12L_as_numerator_and_4L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
-
+    public override void Act() {
+        _fraction = new Fraction(12L, 4L, true);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_double_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void Act() {
-            _fraction = new Fraction((double) 0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
-
+    [Test]
+    // German: Soll der resultierende Bruch im Zähler 3L haben
+    public void Resulting_fraction_should_have_3L_in_numerator() {
+        _fraction.Numerator
+            .Should()
+            .Be(3L);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_decimal_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der resultierende Bruch im Nenner 1L haben
+    public void Resulting_fraction_should_have_1L_in_denominator() {
+        _fraction.Denominator
+            .Should()
+            .Be(1L);
+    }
+}
 
-        public override void Act() {
-            _fraction = new Fraction((decimal) 0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit 0L als Zähler und 4L als Nenner normalisiert erzeugt wird dann
+public class When_fraction_is_created_normalized_with_0L_as_numerator_and_4L_as_denominator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
-
+    public override void Act() {
+        _fraction = new Fraction(0L, 4L, true);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_BigInteger_0_als_Zähler_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der resultierende Bruch im Zähler 0L haben
+    public void Resulting_fraction_should_have_0L_in_numerator() {
+        _fraction.Numerator
+            .Should()
+            .Be(0L);
+    }
 
-        public override void Act() {
-            _fraction = new Fraction((BigInteger) 0);
-        }
+    [Test]
+    // German: Soll der resultierende Bruch im Nenner 0L haben
+    public void Resulting_fraction_should_have_0L_in_denominator() {
+        _fraction.Denominator
+            .Should()
+            .Be(0L);
+    }
+}
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _fraction.Denominator.Should().Be(0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit int 0 als Zähler erzeugt wird
+public class When_fraction_is_created_with_int_0_as_numerator : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _fraction.Numerator.Should().Be(0);
-        }
+    public override void Act() {
+        _fraction = new Fraction(0);
+    }
 
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator.Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit uint 0 als Zähler erzeugt wird
+public class When_fraction_is_created_with_uint_0_as_numerator : Spec {
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = new Fraction((uint)0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator.Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit long 0 als Zähler erzeugt wird
+public class When_fraction_is_created_with_long_0_as_numerator : Spec {
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = new Fraction((long)0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator.Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit ulong 0 als Zähler erzeugt wird
+public class When_fraction_is_created_with_ulong_0_as_numerator : Spec {
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = new Fraction((ulong)0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator.Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit double 0 als Zähler erzeugt wird
+public class When_fraction_is_created_with_double_0_as_numerator : Spec {
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = new Fraction((double)0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator.Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit decimal 0 als Zähler erzeugt wird
+public class When_fraction_is_created_with_decimal_0_as_numerator : Spec {
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = new Fraction((decimal)0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_fraction_should_have_0_as_denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_fraction_should_have_0_as_numerator() {
+        _fraction.Numerator.Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit BigInteger 0 als Zähler erzeugt wird
+public class When_Fraction_Is_Created_With_BigInteger0_As_Numerator : Spec {
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = new Fraction((BigInteger)0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Nenner haben
+    public void Resulting_Fraction_Should_Have_0_As_Denominator() {
+        _fraction.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der resultierende Bruch 0 als Zähler haben
+    public void Resulting_Fraction_Should_Have_0_As_Numerator() {
+        _fraction.Numerator.Should().Be(0);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/ConvertTo/Method_ConvertTo.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ConvertTo/Method_ConvertTo.cs
@@ -2,69 +2,81 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.ConvertTo {
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_NULL_verglichen_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_1_sein() {
-            Fraction.One.CompareTo(null)
-                .Should().Be(1);
-        }
+namespace Fractions.Tests.FractionSpecs.ConvertTo;
+
+[TestFixture]
+// German: Wenn ein Bruch mit NULL verglichen wird
+public class When_comparing_a_fraction_with_NULL : Spec {
+    [Test]
+    // German: Das Ergebnis sollte 1 sein
+    public void The_result_should_be_1() {
+        Fraction.One.CompareTo(null)
+            .Should().Be(1);
+    }
+}
+
+[TestFixture]
+// German: Wenn 1 mit 2 verglichen wird
+public class When_comparing_1_with_2 : Spec {
+    [Test]
+    // German: Das Ergebnis sollte kleiner 0 sein
+    public void The_result_should_be_less_than_0() {
+        Fraction.One.CompareTo(new Fraction(2))
+            .Should().BeLessThan(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn 1 mit minus 2 verglichen wird
+public class When_comparing_1_with_minus_2 : Spec {
+    [Test]
+    // German: Das Ergebnis sollte größer 0 sein
+    public void The_result_should_be_greater_than_0() {
+        Fraction.One.CompareTo(new Fraction(-2))
+            .Should().BeGreaterThan(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn 1 mit 1 verglichen wird
+public class When_comparing_1_with_1 : Spec {
+    [Test]
+    // German: Das Ergebnis sollte gleich 0 sein
+    public void The_result_should_be_0() {
+        Fraction.One.CompareTo(new Fraction(1, 1, false))
+            .Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn 1 Viertel mit 2 Achtel verglichen wird
+public class When_comparing_1_quarter_with_2_eighths : Spec {
+    private Fraction _a;
+    private Fraction _b;
+
+    public override void SetUp() {
+        _a = new Fraction(1, 4, false);
+        _b = new Fraction(2, 8, false);
     }
 
-    [TestFixture]
-    public class Wenn_1_mit_2_verglichen_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_kleiner_0_sein() {
-            Fraction.One.CompareTo(new Fraction(2))
-                .Should().BeLessThan(0);
-        }
+    [Test]
+    // German: Das Ergebnis sollte gleich 0 sein
+    public void The_result_should_be_0() {
+        _a.CompareTo(_b)
+            .Should().Be(0);
     }
 
-    [TestFixture]
-    public class Wenn_1_mit_minus_2_verglichen_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_größer_0_sein() {
-            Fraction.One.CompareTo(new Fraction(-2))
-                .Should().BeGreaterThan(0);
-        }
+    [Test]
+    // German: Diese sollten nicht als vollständig identisch erachtet werden
+    public void These_should_not_be_considered_identical() {
+        _a.Equals(_b)
+            .Should().BeFalse();
     }
 
-    [TestFixture]
-    public class Wenn_1_mit_1_verglichen_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_gleich_0_sein() {
-            Fraction.One.CompareTo(new Fraction(1, 1, false))
-                .Should().Be(0);
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_1_Viertel_mit_2_Achtel_verglichen_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-
-        public override void SetUp() {
-            _a = new Fraction(1, 4, false);
-            _b = new Fraction(2, 8, false);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_gleich_0_sein() {
-            _a.CompareTo(_b)
-                .Should().Be(0);
-        }
-
-        [Test]
-        public void Sollen_diese_nicht_als_vollständig_identisch_erachtet_werden() {
-            _a.Equals(_b)
-                .Should().BeFalse();
-        }
-
-        [Test]
-        public void Sollen_diese_als_Wertgleich_bzw_äquivalent_erachtet_werden() {
-            _a.IsEquivalentTo(_b)
-                .Should().BeTrue();
-        }
+    [Test]
+    // German: Diese sollten als Wertgleich bzw. äquivalent erachtet werden
+    public void These_should_be_considered_equivalent() {
+        _a.IsEquivalentTo(_b)
+            .Should().BeTrue();
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Divide/Method_Divide.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Divide/Method_Divide.cs
@@ -3,152 +3,167 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Divide {
-    [TestFixture]
-    public class Wenn_0_mit_0_dividiert_wird : Spec {
-        private Exception _exception;
+namespace Fractions.Tests.FractionSpecs.Divide;
 
-        public override void Act() {
-            _exception = Catch.Exception(() => Fraction.Zero.Divide(Fraction.Zero));
+[TestFixture]
+// German: Wenn 0 mit 0 dividiert wird
+public class When_dividing_0_by_0 : Spec {
+    private Exception _exception;
 
-        }
-
-        [Test]
-        public void Soll_dies_eine_DivideByZeroException_auslösen() {
-            _exception.Should().BeOfType<DivideByZeroException>();
-        }
+    public override void Act() {
+        _exception = Catch.Exception(() => Fraction.Zero.Divide(Fraction.Zero));
     }
 
-    [TestFixture]
-    public class Wenn_1_mit_0_dividiert_wird : Spec {
-        private Exception _exception;
+    [Test]
+    // German: Dies sollte eine DivideByZeroException auslösen
+    public void This_should_trigger_a_DivideByZeroException() {
+        _exception.Should().BeOfType<DivideByZeroException>();
+    }
+}
 
-        public override void Act() {
-            _exception = Catch.Exception(() => Fraction.One.Divide(Fraction.Zero));
-        }
+[TestFixture]
+// German: Wenn 1 mit 0 dividiert wird
+public class When_dividing_1_by_0 : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_DivideByZeroException_auslösen() {
-            _exception.Should().BeOfType<DivideByZeroException>();
-        }
+    public override void Act() {
+        _exception = Catch.Exception(() => Fraction.One.Divide(Fraction.Zero));
     }
 
-    [TestFixture]
-    public class Wenn_minus_1_mit_0_dividiert_wird : Spec {
-        private Exception _exception;
+    [Test]
+    // German: Dies sollte eine DivideByZeroException auslösen
+    public void This_should_trigger_a_DivideByZeroException() {
+        _exception.Should().BeOfType<DivideByZeroException>();
+    }
+}
 
-        public override void Act() {
-            _exception = Catch.Exception(() => Fraction.MinusOne.Divide(Fraction.Zero));
-        }
+[TestFixture]
+// German: Wenn minus 1 mit 0 dividiert wird
+public class When_dividing_minus_1_by_0 : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_DivideByZeroException_auslösen() {
-            _exception.Should().BeOfType<DivideByZeroException>();
-        }
+    public override void Act() {
+        _exception = Catch.Exception(() => Fraction.MinusOne.Divide(Fraction.Zero));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Fünftel_mit_ein_Fünftel_dividiert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Dies sollte eine DivideByZeroException auslösen
+    public void This_should_trigger_a_DivideByZeroException() {
+        _exception.Should().BeOfType<DivideByZeroException>();
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(1, 5);
-            _b = new Fraction(1, 5);
-        }
+[TestFixture]
+// German: Wenn ein Fünftel mit ein Fünftel dividiert wird
+public class When_dividing_one_fifth_by_one_fifth : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Divide(_b);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_1_sein() {
-            _result.Should().Be(new Fraction(1, 1));
-        }
+    public override void SetUp() {
+        _a = new Fraction(1, 5);
+        _b = new Fraction(1, 5);
     }
 
-    [TestFixture]
-    public class Wenn_2_mit_2_Viertel_dividiert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(2, 1, false);
-            _b = new Fraction(2, 4, false);
-        }
-
-        public override void Act() {
-            _result = _a.Divide(_b);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_4_sein() {
-            _result.Should().Be(new Fraction(4, 1));
-        }
+    public override void Act() {
+        _result = _a.Divide(_b);
     }
 
-    [TestFixture]
-    public class Wenn_minus_2_mit_2_Viertel_dividiert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Das Ergebnis sollte 1 sein
+    public void The_result_should_be_1() {
+        _result.Should().Be(new Fraction(1, 1));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(-2, 1, false);
-            _b = new Fraction(2, 4, false);
-        }
+[TestFixture]
+// German: Wenn 2 mit 2 Viertel dividiert wird
+public class When_dividing_2_by_2_quarters : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Divide(_b);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_minus_4_sein() {
-            _result.Should().Be(new Fraction(-4, 1));
-        }
+    public override void SetUp() {
+        _a = new Fraction(2, 1, false);
+        _b = new Fraction(2, 4, false);
     }
 
-    [TestFixture]
-    public class Wenn_0_Achtel_durch_4_dividiert_werden : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(0, 8, false);
-            _b = new Fraction(4, 1, true);
-        }
-
-        public override void Act() {
-            _result = _a.Divide(_b);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_0_sein() {
-            _result.Should().Be(Fraction.Zero);
-        }
+    public override void Act() {
+        _result = _a.Divide(_b);
     }
 
-    [TestFixture]
-    public class Wenn_0_durch_4_dividiert_werden : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Das Ergebnis sollte 4 sein
+    public void The_result_should_be_4() {
+        _result.Should().Be(new Fraction(4, 1));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(0, 0, false);
-            _b = new Fraction(4, 1, true);
-        }
+[TestFixture]
+// German: Wenn minus 2 mit 2 Viertel dividiert wird
+public class When_dividing_minus_2_by_2_quarters : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Divide(_b);
-        }
+    public override void SetUp() {
+        _a = new Fraction(-2, 1, false);
+        _b = new Fraction(2, 4, false);
+    }
 
-        [Test]
-        public void Soll_das_Ergebnis_0_sein() {
-            _result.Should().Be(Fraction.Zero);
-        }
+    public override void Act() {
+        _result = _a.Divide(_b);
+    }
+
+    [Test]
+    // German: Das Ergebnis sollte minus 4 sein
+    public void The_result_should_be_minus_4() {
+        _result.Should().Be(new Fraction(-4, 1));
+    }
+}
+
+[TestFixture]
+// German: Wenn 0 Achtel durch 4 dividiert werden
+public class When_dividing_0_eighths_by_4 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = new Fraction(0, 8, false);
+        _b = new Fraction(4, 1, true);
+    }
+
+    public override void Act() {
+        _result = _a.Divide(_b);
+    }
+
+    [Test]
+    // German: Das Ergebnis sollte 0 sein
+    public void The_result_should_be_0() {
+        _result.Should().Be(Fraction.Zero);
+    }
+}
+
+[TestFixture]
+// German: Wenn 0 durch 4 dividiert werden
+public class When_dividing_0_by_4 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = new Fraction(0, 0, false);
+        _b = new Fraction(4, 1, true);
+    }
+
+    public override void Act() {
+        _result = _a.Divide(_b);
+    }
+
+    [Test]
+    // German: Das Ergebnis sollte 0 sein
+    public void The_result_should_be_0() {
+        _result.Should().Be(Fraction.Zero);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/FromDecimal/Method_FromDecimal.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDecimal/Method_FromDecimal.cs
@@ -1,164 +1,161 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.FromDecimal {
+namespace Fractions.Tests.FractionSpecs.FromDecimal;
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_0_decimal_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+[TestFixture]
+public class When_a_fraction_is_created_with_a_0_decimal_number : Spec {
+    private Fraction _fraction;
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(decimal.Zero);
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(decimal.Zero);
+    }
 
-        [Test]
-        public void Soll_der_Wert_danach_0_sein() {
-            _fraction.Should().Be(Fraction.Zero);
+    [Test]
+    public void The_value_should_then_be_0() {
+        _fraction.Should().Be(Fraction.Zero);
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_a_minus_1_decimal_number : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(decimal.MinusOne);
+    }
+
+    [Test]
+    public void The_value_should_then_be_minus_1() {
+        _fraction.Should().Be(new Fraction(-1, 1));
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_a_1_decimal_number : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(decimal.One);
+    }
+
+    [Test]
+    public void The_value_should_then_be_1() {
+        _fraction.Should().Be(new Fraction(1, 1));
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_a_1_point_345_decimal_number : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(1.345m);
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_numerator_of_269() {
+        _fraction.Numerator.Should().Be(new BigInteger(269));
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_denominator_of_200() {
+        _fraction.Denominator.Should().Be(new BigInteger(200));
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_decimal_MaxValue : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(decimal.MaxValue);
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_numerator_of_decimal_MaxValue() {
+        _fraction.Numerator.Should().Be(new BigInteger(decimal.MaxValue));
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_denominator_of_1() {
+        _fraction.Denominator.Should().Be(new BigInteger(1));
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_decimal_MinValue : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(decimal.MinValue);
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_numerator_of_minus_decimal_MaxValue() {
+        _fraction.Numerator.Should().Be(BigInteger.Negate(new BigInteger(decimal.MaxValue)));
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_denominator_of_1() {
+        _fraction.Denominator.Should().Be(new BigInteger(1));
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_1_third : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDecimal(1.0m / 3.0m);
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_numerator_of_3333333333333333333333333333() {
+        _fraction.Numerator.Should().Be(BigInteger.Parse("3333333333333333333333333333"));
+    }
+
+    [Test]
+    public void The_fraction_should_then_have_a_denominator_of_10000000000000000000000000000() {
+        _fraction.Denominator.Should().Be(BigInteger.Parse("10000000000000000000000000000"));
+    }
+
+    [Test]
+    public void The_fraction_should_have_the_value_0_33333333333333() {
+        _fraction.ToDecimal().Should().Be(1.0m / 3.0m);
+    }
+}
+
+[TestFixture]
+public class When_a_fraction_is_created_with_decimal_test_numbers : Spec {
+    private static IEnumerable<TestCaseData> TestCaseSource {
+        get {
+            yield return new TestCaseData(10000000000000000000000000000.0m);
+            yield return new TestCaseData(100000000000000.0m);
+            yield return new TestCaseData(100000000000000.00000000000000m);
+            yield return new TestCaseData(123456789.0m);
+            yield return new TestCaseData(0.123456789m);
+            yield return new TestCaseData(0.000000000123456789m);
+            yield return new TestCaseData(4294967295.0m);
+            yield return new TestCaseData(18446744073709551615.0m);
+            yield return new TestCaseData(7.9228162514264337593543950335m);
         }
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_minus_1_decimal_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(decimal.MinusOne);
-        }
-
-        [Test]
-        public void Soll_der_Wert_danach_minus_1_sein() {
-            _fraction.Should().Be(new Fraction(-1, 1));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_1_decimal_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(decimal.One);
-        }
-
-        [Test]
-        public void Soll_der_Wert_danach_1_sein() {
-            _fraction.Should().Be(new Fraction(1, 1));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_1_Komma_345_decimal_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(1.345m);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_269_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(269));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_200_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(200));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_decimal_MaxValue_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(decimal.MaxValue);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_decimal_MaxValue_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(decimal.MaxValue));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_1_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(1));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_decimal_MinValue_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(decimal.MinValue);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_minus_decimal_MaxValue_haben() {
-            _fraction.Numerator.Should().Be(BigInteger.Negate(new BigInteger(decimal.MaxValue)));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_1_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(1));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_1_Drittel_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDecimal(1.0m / 3.0m);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_3333333333333333333333333333_haben() {
-            _fraction.Numerator.Should().Be(BigInteger.Parse("3333333333333333333333333333"));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_10000000000000000000000000000_haben() {
-            _fraction.Denominator.Should().Be(BigInteger.Parse("10000000000000000000000000000"));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_den_Wert_0_33333333333333_haben() {
-            _fraction.ToDecimal().Should().Be(1.0m / 3.0m);
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_Decimaltestzahlen_erzeugt_wird : Spec {
-        private static IEnumerable<TestCaseData> TestCaseSource {
-            get {
-                yield return new TestCaseData(10000000000000000000000000000.0m);
-                yield return new TestCaseData(100000000000000.0m);
-                yield return new TestCaseData(100000000000000.00000000000000m);
-                yield return new TestCaseData(123456789.0m);
-                yield return new TestCaseData(0.123456789m);
-                yield return new TestCaseData(0.000000000123456789m);
-                yield return new TestCaseData(4294967295.0m);
-                yield return new TestCaseData(18446744073709551615.0m);
-                yield return new TestCaseData(7.9228162514264337593543950335m);
-            }
-
-        }
-
-        [Test, TestCaseSource(nameof(TestCaseSource))]
-        public void Soll_der_Bruch_nach_der_Rueckumwandlung_zu_decimal_den_selben_Wert_haben(decimal value) {
-            var fraction = Fraction.FromDecimal(value);
-
-            fraction.ToDecimal().Should().Be(value);
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCaseSource))]
+    public void The_fraction_should_have_the_same_value_after_being_converted_back_to_decimal(decimal value) {
+        var fraction = Fraction.FromDecimal(value);
+        fraction.ToDecimal().Should().Be(value);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/FromDouble/Method_FromDouble.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDouble/Method_FromDouble.cs
@@ -4,255 +4,288 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.FromDouble {
-    [TestFixture]
-    public class Wenn_ein_Bruch_anhand_einer_NaN_double_Zahl_erzeugt_wird : Spec {
-        private Exception _exception;
+namespace Fractions.Tests.FractionSpecs.FromDouble;
 
-        public override void SetUp() {
-            base.SetUp();
-            _exception = Catch.Exception(() => Fraction.FromDouble(double.NaN));
-        }
+[TestFixture]
+// German: Wenn ein Bruch anhand einer NaN double Zahl erzeugt wird
+public class When_a_fraction_is_created_from_a_NaN_double : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_NotANumberException_auslösen() {
-            _exception.Should().BeOfType<InvalidNumberException>();
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _exception = Catch.Exception(() => Fraction.FromDouble(double.NaN));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_anhand_einer_positiv_unendlichen_double_Zahl_erzeugt_wird : Spec {
-        private Exception _exception;
+    [Test]
+    // German: Soll dies eine InvalidNumberException auslösen
+    public void Should_throw_an_InvalidNumberException() {
+        _exception.Should().BeOfType<InvalidNumberException>();
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _exception = Catch.Exception(() => Fraction.FromDouble(double.PositiveInfinity));
-        }
+[TestFixture]
+// German: Wenn ein Bruch anhand einer positiv unendlichen double Zahl erzeugt wird
+public class When_a_fraction_is_created_from_a_positive_infinite_double : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_NotANumberException_auslösen() {
-            _exception.Should().BeOfType<InvalidNumberException>();
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _exception = Catch.Exception(() => Fraction.FromDouble(double.PositiveInfinity));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_anhand_einer_negativ_unendlichen_double_Zahl_erzeugt_wird : Spec {
-        private Exception _exception;
+    [Test]
+    // German: Soll dies eine InvalidNumberException auslösen
+    public void Should_throw_an_InvalidNumberException() {
+        _exception.Should().BeOfType<InvalidNumberException>();
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _exception = Catch.Exception(() => Fraction.FromDouble(double.NegativeInfinity));
-        }
+[TestFixture]
+// German: Wenn ein Bruch anhand einer negativ unendlichen double Zahl erzeugt wird
+public class When_a_fraction_is_created_from_a_negative_infinite_double : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_NotANumberException_auslösen() {
-            _exception.Should().BeOfType<InvalidNumberException>();
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _exception = Catch.Exception(() => Fraction.FromDouble(double.NegativeInfinity));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_0_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll dies eine InvalidNumberException auslösen
+    public void Should_throw_an_InvalidNumberException() {
+        _exception.Should().BeOfType<InvalidNumberException>();
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(0.0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 0 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_0_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Wert_danach_0_sein() {
-            _fraction.Should().Be(Fraction.Zero);
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(0.0);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_minus_1_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Wert danach 0 sein
+    public void The_value_after_should_be_0() {
+        _fraction.Should().Be(Fraction.Zero);
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(-1.0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer minus 1 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_minus_1_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Wert_danach_minus_1_sein() {
-            _fraction.Should().Be(new Fraction(-1, 1));
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(-1.0);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_1_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Wert danach minus 1 sein
+    public void The_value_after_should_be_minus_1() {
+        _fraction.Should().Be(new Fraction(-1, 1));
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(1);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 1 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_1_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Wert_danach_1_sein() {
-            _fraction.Should().Be(new Fraction(1, 1));
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(1);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_1_Komma_345_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Wert danach 1 sein
+    public void The_value_after_should_be_1() {
+        _fraction.Should().Be(new Fraction(1, 1));
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(1.345);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 1 Komma 345 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_1_point_345_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_auf_15_Nachkommastellen_gerundete_Wert_der_Zahl_entsprechen() {
-            var rounded = Math.Round(_fraction.ToDouble(), 15, MidpointRounding.ToEven);
-            rounded.Should().Be(1.345);
-        }
-
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(1.345);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_0_Komma_3125_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der auf 15 Nachkommastellen gerundete Wert der Zahl entsprechen
+    public void The_value_rounded_to_15_decimal_places_should_match_the_number() {
+        var rounded = Math.Round(_fraction.ToDouble(), 15, MidpointRounding.ToEven);
+        rounded.Should().Be(1.345);
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(0.3125);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 0 Komma 3125 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_0_point_3125_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_5_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(5));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_16_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(16));
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(0.3125);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_minus_0_Komma_3125_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(-0.3125);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_minus_5_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(-5));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_16_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(16));
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von 5 haben
+    public void The_fraction_should_have_a_numerator_of_5() {
+        _fraction.Numerator.Should().Be(new BigInteger(5));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_double_MaxValue_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 16 haben
+    public void The_fraction_should_have_a_denominator_of_16() {
+        _fraction.Denominator.Should().Be(new BigInteger(16));
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(double.MaxValue);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer minus 0 Komma 3125 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_minus_0_point_3125_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_double_MaxValue_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(double.MaxValue));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_1_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(1));
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(-0.3125);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_double_MinValue_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(double.MinValue);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_minus_double_MaxValue_haben() {
-            _fraction.Numerator.Should().Be(BigInteger.Negate(new BigInteger(double.MaxValue)));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_1_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(1));
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von minus 5 haben
+    public void The_fraction_should_have_a_numerator_of_minus_5() {
+        _fraction.Numerator.Should().Be(new BigInteger(-5));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_PI_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 16 haben
+    public void The_fraction_should_have_a_denominator_of_16() {
+        _fraction.Denominator.Should().Be(new BigInteger(16));
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(Math.PI);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit double MaxValue erzeugt wird
+public class When_a_fraction_is_created_with_double_MaxValue : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Bruch_zurück_in_Double_umgewandelt_mit_PI_gleich_sein() {
-            _fraction.ToDouble().Should().Be(Math.PI);
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(double.MaxValue);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_von_0_komma_1_ohne_Rundung_erzeugt_wird : Spec
-    {
-        private Fraction _fraction;
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(0.1);
-            Console.WriteLine(_fraction.ToString());
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_3602879701896397_durch_36028797018963968_sein() {
-            _fraction.Should().Be(new Fraction(3602879701896397L, 36028797018963968L));
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von double MaxValue haben
+    public void The_fraction_should_have_a_numerator_of_double_MaxValue() {
+        _fraction.Numerator.Should().Be(new BigInteger(double.MaxValue));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_von_0_komma_1_mit_Rundung_erzeugt_wird : Spec
-    {
-        private Fraction _fraction;
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDoubleRounded(0.1);
-            Console.WriteLine(_fraction.ToString());
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 1 haben
+    public void The_fraction_should_have_a_denominator_of_1() {
+        _fraction.Denominator.Should().Be(new BigInteger(1));
+    }
+}
 
-        [Test]
-        public void Soll_das_Ergebnis_1_durch_10_sein() {
-            _fraction.Should().Be(new Fraction(1, 10));
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit double MinValue erzeugt wird
+public class When_a_fraction_is_created_with_double_MinValue : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(double.MinValue);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_1_Drittel_erzeugt_wird : Spec {
-        private Fraction _fraction;
-        private const double ONE_THIRD = 1.0 / 3.0;
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von minus double MaxValue haben
+    public void The_fraction_should_have_a_numerator_of_minus_double_MaxValue() {
+        _fraction.Numerator.Should().Be(BigInteger.Negate(new BigInteger(double.MaxValue)));
+    }
 
-        public override void SetUp() {
-            base.SetUp();
-            _fraction = Fraction.FromDouble(ONE_THIRD);
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 1 haben
+    public void The_fraction_should_have_a_denominator_of_1() {
+        _fraction.Denominator.Should().Be(new BigInteger(1));
+    }
+}
 
-        [Test]
-        public void Soll_der_auf_15_Nachkommastellen_gerundete_Wert_der_Zahl_entsprechen() {
-            var rounded = Math.Round(_fraction.ToDouble(), 15, MidpointRounding.ToEven);
-            rounded.Should().Be(0.333333333333333);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit PI erzeugt wird
+public class When_a_fraction_is_created_with_PI : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(Math.PI);
+    }
+
+    [Test]
+    // German: Soll der Bruch zurück in Double umgewandelt mit PI gleich sein
+    public void When_converted_back_to_double_the_fraction_should_equal_PI() {
+        _fraction.ToDouble().Should().Be(Math.PI);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch von 0 komma 1 ohne Rundung erzeugt wird
+public class When_a_fraction_is_created_from_0_point_1_without_rounding : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(0.1);
+        Console.WriteLine(_fraction.ToString());
+    }
+
+    [Test]
+    // German: Soll das Ergebnis 3602879701896397 durch 36028797018963968 sein
+    public void The_result_should_be_3602879701896397_over_36028797018963968() {
+        _fraction.Should().Be(new Fraction(3602879701896397L, 36028797018963968L));
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch von 0 komma 1 mit Rundung erzeugt wird
+public class When_a_fraction_is_created_from_0_point_1_with_rounding : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDoubleRounded(0.1);
+        Console.WriteLine(_fraction.ToString());
+    }
+
+    [Test]
+    // German: Soll das Ergebnis 1 durch 10 sein
+    public void The_result_should_be_1_over_10() {
+        _fraction.Should().Be(new Fraction(1, 10));
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit 1 Drittel erzeugt wird
+public class When_a_fraction_is_created_with_1_third : Spec {
+    private Fraction _fraction;
+    private const double ONE_THIRD = 1.0 / 3.0;
+
+    public override void SetUp() {
+        base.SetUp();
+        _fraction = Fraction.FromDouble(ONE_THIRD);
+    }
+
+    [Test]
+    // German: Soll der auf 15 Nachkommastellen gerundete Wert der Zahl entsprechen
+    public void The_value_rounded_to_15_decimal_places_should_match_the_number() {
+        var rounded = Math.Round(_fraction.ToDouble(), 15, MidpointRounding.ToEven);
+        rounded.Should().Be(0.333333333333333);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
@@ -4,184 +4,210 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.FromDoubleRounded {
+namespace Fractions.Tests.FractionSpecs.FromDoubleRounded;
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_anhand_einer_NaN_double_Zahl_erzeugt_wird : Spec {
-        private Exception _exception;
+[TestFixture]
+// German: Wenn ein Bruch anhand einer NaN double Zahl erzeugt wird
+public class When_a_fraction_is_created_based_on_a_NaN_double : Spec {
+    private Exception _exception;
 
-        public override void SetUp() {
-            _exception = Catch.Exception(() => Fraction.FromDoubleRounded(double.NaN));
-        }
-
-        [Test]
-        public void Soll_dies_eine_NotANumberException_auslösen() {
-            _exception.Should().BeOfType<InvalidNumberException>();
-        }
+    public override void SetUp() {
+        _exception = Catch.Exception(() => Fraction.FromDoubleRounded(double.NaN));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_anhand_einer_positiv_unendlichen_double_Zahl_erzeugt_wird : Spec {
-        private Exception _exception;
+    [Test]
+    // German: Soll dies eine InvalidNumberException auslösen
+    public void This_should_trigger_an_InvalidNumberException() {
+        _exception.Should().BeOfType<InvalidNumberException>();
+    }
+}
 
-        public override void SetUp() {
-            _exception = Catch.Exception(() => Fraction.FromDoubleRounded(double.PositiveInfinity));
-        }
+[TestFixture]
+// German: Wenn ein Bruch anhand einer positiv unendlichen double Zahl erzeugt wird
+public class When_a_fraction_is_created_based_on_a_positive_infinite_double : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_NotANumberException_auslösen() {
-            _exception.Should().BeOfType<InvalidNumberException>();
-        }
+    public override void SetUp() {
+        _exception = Catch.Exception(() => Fraction.FromDoubleRounded(double.PositiveInfinity));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_anhand_einer_negativ_unendlichen_double_Zahl_erzeugt_wird : Spec {
-        private Exception _exception;
+    [Test]
+    // German: Soll dies eine InvalidNumberException auslösen
+    public void This_should_trigger_an_InvalidNumberException() {
+        _exception.Should().BeOfType<InvalidNumberException>();
+    }
+}
 
-        public override void SetUp() {
-            _exception = Catch.Exception(() => Fraction.FromDoubleRounded(double.NegativeInfinity));
-        }
+[TestFixture]
+// German: Wenn ein Bruch anhand einer negativ unendlichen double Zahl erzeugt wird
+public class When_a_fraction_is_created_based_on_a_negative_infinite_double : Spec {
+    private Exception _exception;
 
-        [Test]
-        public void Soll_dies_eine_NotANumberException_auslösen() {
-            _exception.Should().BeOfType<InvalidNumberException>();
-        }
+    public override void SetUp() {
+        _exception = Catch.Exception(() => Fraction.FromDoubleRounded(double.NegativeInfinity));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_0_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll dies eine InvalidNumberException auslösen
+    public void This_should_trigger_an_InvalidNumberException() {
+        _exception.Should().BeOfType<InvalidNumberException>();
+    }
+}
 
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 0 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_0_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Wert_danach_0_sein() {
-            _fraction.Should().Be(Fraction.Zero);
-        }
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(0);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_minus_1_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Wert danach 0 sein
+    public void The_value_should_then_be_0() {
+        _fraction.Should().Be(Fraction.Zero);
+    }
+}
 
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(-1);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer minus 1 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_minus_1_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Wert_danach_minus_1_sein() {
-            _fraction.Should().Be(new Fraction(-1, 1));
-        }
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(-1);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_1_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Wert danach minus 1 sein
+    public void The_value_should_then_be_minus_1() {
+        _fraction.Should().Be(new Fraction(-1, 1));
+    }
+}
 
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(1);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 1 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_1_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Wert_danach_1_sein() {
-            _fraction.Should().Be(new Fraction(1, 1));
-        }
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(1);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_einer_1_Komma_345_double_Zahl_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Wert danach 1 sein
+    public void The_value_should_then_be_1() {
+        _fraction.Should().Be(new Fraction(1, 1));
+    }
+}
 
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(1.345);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit einer 1 Komma 345 double Zahl erzeugt wird
+public class When_a_fraction_is_created_with_a_1_point_345_double : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_269_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(269));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_200_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(200));
-        }
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(1.345);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_double_MaxValue_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(double.MaxValue);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_double_MaxValue_haben() {
-            _fraction.Numerator.Should().Be(new BigInteger(double.MaxValue));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_1_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(1));
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von 269 haben
+    public void The_fraction_should_then_have_a_numerator_of_269() {
+        _fraction.Numerator.Should().Be(new BigInteger(269));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_double_MinValue_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 200 haben
+    public void The_fraction_should_then_have_a_denominator_of_200() {
+        _fraction.Denominator.Should().Be(new BigInteger(200));
+    }
+}
 
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(double.MinValue);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit double MaxValue erzeugt wird
+public class When_a_fraction_is_created_with_double_MaxValue : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_minus_double_MaxValue_haben() {
-            _fraction.Numerator.Should().Be(BigInteger.Negate(new BigInteger(double.MaxValue)));
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_1_haben() {
-            _fraction.Denominator.Should().Be(new BigInteger(1));
-        }
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(double.MaxValue);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_PI_erzeugt_wird : Spec {
-        private Fraction _fraction;
-
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(Math.PI);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_245850922_haben() {
-            _fraction.Numerator.Should().Be(245850922);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_78256779_haben() {
-            _fraction.Denominator.Should().Be(78256779);
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von double MaxValue haben
+    public void The_fraction_should_then_have_a_numerator_of_double_MaxValue() {
+        _fraction.Numerator.Should().Be(new BigInteger(double.MaxValue));
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_1_Drittel_erzeugt_wird : Spec {
-        private Fraction _fraction;
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 1 haben
+    public void The_fraction_should_then_have_a_denominator_of_1() {
+        _fraction.Denominator.Should().Be(new BigInteger(1));
+    }
+}
 
-        public override void SetUp() {
-            _fraction = Fraction.FromDoubleRounded(1.0 / 3.0);
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit double MinValue erzeugt wird
+public class When_a_fraction_is_created_with_double_MinValue : Spec {
+    private Fraction _fraction;
 
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Zähler_von_1_haben() {
-            _fraction.Numerator.Should().Be(1);
-        }
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(double.MinValue);
+    }
 
-        [Test]
-        public void Soll_der_Bruch_danach_einen_Nenner_von_3_haben() {
-            _fraction.Denominator.Should().Be(3);
-        }
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von minus double MaxValue haben
+    public void The_fraction_should_then_have_a_numerator_of_minus_double_MaxValue() {
+        _fraction.Numerator.Should().Be(BigInteger.Negate(new BigInteger(double.MaxValue)));
+    }
+
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 1 haben
+    public void The_fraction_should_then_have_a_denominator_of_1() {
+        _fraction.Denominator.Should().Be(new BigInteger(1));
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit PI erzeugt wird
+public class When_a_fraction_is_created_with_PI : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(Math.PI);
+    }
+
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von 245850922 haben
+    public void The_fraction_should_then_have_a_numerator_of_245850922() {
+        _fraction.Numerator.Should().Be(245850922);
+    }
+
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 78256779 haben
+    public void The_fraction_should_then_have_a_denominator_of_78256779() {
+        _fraction.Denominator.Should().Be(78256779);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit 1 Drittel erzeugt wird
+public class When_a_fraction_is_created_with_1_third : Spec {
+    private Fraction _fraction;
+
+    public override void SetUp() {
+        _fraction = Fraction.FromDoubleRounded(1.0 / 3.0);
+    }
+
+    [Test]
+    // German: Soll der Bruch danach einen Zähler von 1 haben
+    public void The_fraction_should_then_have_a_numerator_of_1() {
+        _fraction.Numerator.Should().Be(1);
+    }
+
+    [Test]
+    // German: Soll der Bruch danach einen Nenner von 3 haben
+    public void The_fraction_should_then_have_a_denominator_of_3() {
+        _fraction.Denominator.Should().Be(3);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
@@ -4,154 +4,184 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.FromString {
-    [TestFixture]
-    public class Wenn_versucht_wird_aus_einem_Leerstring_ein_Bruch_zu_erzeugen : Spec {
-        [Test]
-        public void Soll_dies_nicht_funktionieren([Values("", " ")] string invalidString) {
-            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-            Invoking(() => Fraction.FromString(invalidString))
-                .Should()
-                .Throw<FormatException>();
-        }
+namespace Fractions.Tests.FractionSpecs.FromString;
+
+[TestFixture]
+// German: Wenn versucht wird, aus einem Leerstring einen Bruch zu erzeugen
+public class When_trying_to_create_a_fraction_from_an_empty_string : Spec {
+    [Test]
+    // German: Dies sollte nicht funktionieren
+    public void This_should_not_work([Values("", " ")] string invalidString) {
+        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+        Invoking(() => Fraction.FromString(invalidString))
+            .Should()
+            .Throw<FormatException>();
+    }
+}
+
+[TestFixture]
+// German: Wenn aus 999999999999999999999 ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_999999999999999999999 : Spec {
+    private Fraction _result;
+
+    public override void Act() {
+        _result = Fraction.FromString("999999999999999999999");
     }
 
-    [TestFixture]
-    public class Wenn_aus_999999999999999999999_ein_Bruch_zu_erzeugt_wird : Spec {
-        private Fraction _result;
-
-        public override void Act() {
-            _result = Fraction.FromString("999999999999999999999");
-        }
-
-        [Test]
-        public void Soll_der_Zähler_des_Bruches_999999999999999999999_sein() {
-            _result.Numerator.ToString()
-                .Should().Be("999999999999999999999");
-        }
-
-        [Test]
-        public void Soll_der_Nenner_des_Bruches_1_sein() {
-            _result.Denominator
-                .Should().Be(1);
-        }
+    [Test]
+    // German: Der Zähler des Bruches sollte 999999999999999999999 sein
+    public void The_numerator_of_the_fraction_should_be_999999999999999999999() {
+        _result.Numerator.ToString()
+            .Should().Be("999999999999999999999");
     }
 
-    [TestFixture]
-    [Culture("de-DE")]
-    public class Wenn_aus_minus_999999999999999999999_ein_Bruch_zu_erzeugt_wird : Spec {
-        private Fraction _result;
+    [Test]
+    // German: Der Nenner des Bruches sollte 1 sein
+    public void The_denominator_of_the_fraction_should_be_1() {
+        _result.Denominator
+            .Should().Be(1);
+    }
+}
 
-        public override void Act() {
-            _result = Fraction.FromString("-999999999999999999999");
-        }
+[TestFixture]
+[Culture("de-DE")]
+// German: Wenn aus minus 999999999999999999999 mit deutscher Kultur ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_minus_999999999999999999999_with_German_culture : Spec {
+    private Fraction _result;
 
-        [Test]
-        public void Soll_der_Zähler_des_Bruches_minus_999999999999999999999_sein() {
-            _result.Numerator.ToString()
-                .Should().Be("-999999999999999999999");
-        }
-
-        [Test]
-        public void Soll_der_Nenner_des_Bruches_1_sein() {
-            _result.Denominator
-                .Should().Be(1);
-        }
+    public override void Act() {
+        _result = Fraction.FromString("-999999999999999999999");
     }
 
-    [TestFixture]
-    public class Wenn_aus_3_Komma_5_mit_deutscher_Kultur_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_7_durch_2_sein(
-            [Values("3,5", " 3,5", "3,5 ", "+3,5", " +3,5", "+3,5 ")] string value) {
-            Fraction.FromString(value, new CultureInfo("de-DE"))
-                .Should().Be(new Fraction(7, 2));
-        }
+    [Test]
+    // German: Der Zähler des Bruches sollte minus 999999999999999999999 sein
+    public void The_numerator_of_the_fraction_should_be_minus_999999999999999999999() {
+        _result.Numerator.ToString()
+            .Should().Be("-999999999999999999999");
     }
 
-    [TestFixture]
-    [Culture("de-DE")]
-    public class Wenn_aus_3_Komma_5_ohne_explizite_Angabe_der_Kultur_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_7_durch_2_sein(
-            [Values("3,5", " 3,5", "3,5 ", "+3,5", " +3,5", "+3,5 ")] string value) {
-            Fraction.FromString(value)
-                .Should().Be(new Fraction(7, 2));
-        }
+    [Test]
+    // German: Der Nenner des Bruches sollte 1 sein
+    public void The_denominator_of_the_fraction_should_be_1() {
+        _result.Denominator
+            .Should().Be(1);
+    }
+}
+
+[TestFixture]
+// German: Wenn aus 3,5 mit deutscher Kultur ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_3_5_with_German_culture : Spec {
+    [Test]
+    // German: Das Ergebnis sollte 7 durch 2 sein
+    public void The_result_should_be_7_over_2(
+        [Values("3,5", " 3,5", "3,5 ", "+3,5", " +3,5", "+3,5 ")]
+        string value) {
+        Fraction.FromString(value, new CultureInfo("de-DE"))
+            .Should().Be(new Fraction(7, 2));
+    }
+}
+
+[TestFixture]
+[Culture("de-DE")]
+// German: Wenn aus 3,5 ohne explizite Angabe der Kultur ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_3_5_without_explicit_culture_specification : Spec {
+    [Test]
+    // German: Das Ergebnis sollte 7 durch 2 sein
+    public void The_result_should_be_7_over_2(
+        [Values("3,5", " 3,5", "3,5 ", "+3,5", " +3,5", "+3,5 ")]
+        string value) {
+        Fraction.FromString(value)
+            .Should().Be(new Fraction(7, 2));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus minus 3,5 mit deutscher Kultur ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_minus_3_5_with_German_culture : Spec {
+    [Test]
+    // German: Das Ergebnis sollte minus 7 durch 2 sein
+    public void The_result_should_be_minus_7_over_2([Values("-3,5", " -3,5", "-3,5 ")] string value) {
+        Fraction.FromString(value, new CultureInfo("de-DE"))
+            .Should().Be(new Fraction(-7, 2));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus 3.5 mit US-amerikanischer Kultur ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_3_5_with_American_culture : Spec {
+    private Fraction _result;
+
+    public override void Act() {
+        _result = Fraction.FromString("3.5", new CultureInfo("en-US"));
     }
 
-    [TestFixture]
-    public class Wenn_aus_minus_3_Komma_5_mit_deutscher_Kultur_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_minus_7_durch_2_sein([Values("-3,5", " -3,5", "-3,5 ")] string value) {
-            Fraction.FromString(value, new CultureInfo("de-DE"))
-                .Should().Be(new Fraction(-7, 2));
-        }
+    [Test]
+    // German: Das Ergebnis sollte 7 durch 2 sein
+    public void The_result_should_be_7_over_2() {
+        _result.Should().Be(new Fraction(7, 2));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus der Zeichenkette 1/5 ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_the_string_1_over_5 : Spec {
+    [Test]
+    // German: Das Ergebnis sollte 1 durch 5 sein
+    public void The_result_should_be_1_over_5([Values("1/5", "-1/-5", "+1/5", "+1/+5", "1/+5")] string value) {
+        Fraction.FromString(value)
+            .Should().Be(new Fraction(1, 5));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus der Zeichenkette minus 1/5 ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_the_string_minus_1_over_5 : Spec {
+    [Test]
+    // German: Das Ergebnis sollte minus 1 durch 5 sein
+    public void The_result_should_be_minus_1_over_5([Values("-1/5", "1/-5")] string value) {
+        Fraction.FromString(value)
+            .Should().Be(new Fraction(-1, 5));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus der Zeichenkette 64/40 mit beliebigen Leerzeichen ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_the_string_64_over_40_with_any_spaces : Spec {
+    [Test]
+    // German: Das Ergebnis sollte 64 durch 40 sein
+    public void The_result_should_be_64_over_40(
+        [Values("64/40 ", " 64/40", "64/ 40", "64 /40", "64 / 40")]
+        string value) {
+        Fraction.FromString(value)
+            .Should().Be(new Fraction(8, 5));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus der Zeichenkette minus 64/40 mit beliebigen Leerzeichen ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_the_string_minus_64_over_40_with_any_spaces : Spec {
+    [Test]
+    // German: Das Ergebnis sollte 64 durch 40 sein
+    public void The_result_should_be_64_over_40(
+        [Values("-64/40", " -64/40", "-64/ 40", "64 /-40", "64 / -40")]
+        string value) {
+        Fraction.FromString(value)
+            .Should().Be(new Fraction(-8, 5));
+    }
+}
+
+[TestFixture]
+// German: Wenn aus der Zeichenkette minus 64/40 durch explizite Umwandlung ein Bruch erzeugt wird
+public class When_creating_a_fraction_from_the_string_minus_64_over_40_by_explicit_conversion : Spec {
+    private Fraction _result;
+
+    public override void Act() {
+        _result = (Fraction)"-64/40";
     }
 
-    [TestFixture]
-    public class Wenn_aus_3_Punkt_5_mit_US_amerikanischer_Kultur_ein_Bruch_erzeugt_wird : Spec {
-        private Fraction _result;
-
-        public override void Act() {
-            _result = Fraction.FromString("3.5", new CultureInfo("en-US"));
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_7_durch_2_sein() {
-            _result.Should().Be(new Fraction(7, 2));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_aus_der_Zeichenkette_1_Slash_5_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_1_durch_5_sein([Values("1/5", "-1/-5", "+1/5", "+1/+5", "1/+5")] string value) {
-            Fraction.FromString(value)
-                .Should().Be(new Fraction(1, 5));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_aus_der_Zeichenkette_minus_1_Slash_5_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_minus_1_durch_5_sein([Values("-1/5", "1/-5")] string value) {
-            Fraction.FromString(value)
-                .Should().Be(new Fraction(-1, 5));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_aus_der_Zeichenkette_64_Slash_40_mit_beliebigen_Leerzeichen_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_64_durch_40_sein(
-            [Values("64/40 ", " 64/40", "64/ 40", "64 /40", "64 / 40")] string value) {
-            Fraction.FromString(value)
-                .Should().Be(new Fraction(8, 5));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_aus_der_Zeichenkette_minus_64_Slash_40_mit_beliebigen_Leerzeichen_ein_Bruch_erzeugt_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_64_durch_40_sein(
-            [Values("-64/40", " -64/40", "-64/ 40", "64 /-40", "64 / -40")] string value) {
-            Fraction.FromString(value)
-                .Should().Be(new Fraction(-8, 5));
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_aus_der_Zeichenkette_minus_64_Slash_40_durch_explizite_Umwandlung_ein_Bruch_erzeugt_wird : Spec {
-        private Fraction _result;
-
-        public override void Act() {
-            _result = (Fraction) "-64/40";
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_korrekt_sein() {
-            _result.Should().Be(new Fraction(-64, 40));
-        }
+    [Test]
+    // German: Das Ergebnis sollte korrekt sein
+    public void The_result_should_be_correct() {
+        _result.Should().Be(new Fraction(-64, 40));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Invert/Method_Invert.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Invert/Method_Invert.cs
@@ -2,100 +2,114 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Invert {
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_0_als_Zähler_und_0_als_Nenner_negiert_wird : Spec {
-        private Fraction _result;
+namespace Fractions.Tests.FractionSpecs.Invert;
 
-        public override void Act() {
-            _result = new Fraction(0, 0, false).Invert();
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit 0 als Zähler und 0 als Nenner negiert wird
+public class When_negating_a_fraction_with_0_as_numerator_and_0_as_denominator : Spec {
+    private Fraction _result;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _result.Numerator
-                .Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _result.Denominator
-                .Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_0_sein() {
-            _result.IsZero
-                .Should().BeTrue();
-        }
+    public override void Act() {
+        _result = new Fraction(0, 0, false).Invert();
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_0_als_Zähler_und_4_als_Nenner_negiert_wird : Spec {
-        private Fraction _result;
-
-        public override void Act() {
-            _result = new Fraction(0, 4, false).Invert();
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Zähler_haben() {
-            _result.Numerator
-                .Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_0_als_Nenner_haben() {
-            _result.Denominator
-                .Should().Be(0);
-        }
-
-        [Test]
-        public void Soll_der_Bruch_0_sein() {
-            _result.IsZero
-                .Should().BeTrue();
-        }
+    [Test]
+    // German: Der resultierende Bruch sollte 0 als Zähler haben
+    public void The_resulting_fraction_should_have_0_as_numerator() {
+        _result.Numerator
+            .Should().Be(0);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_minus_1_als_Zähler_und_1_als_Nenner_negiert_wird : Spec {
-        private Fraction _result;
-
-        public override void Act() {
-            _result = new Fraction(-1, 1, false).Invert();
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_1_als_Zähler_haben() {
-            _result.Numerator
-                .Should().Be(1);
-        }
-
-        [Test]
-        public void Soll_der_resultierende_Bruch_1_als_Nenner_haben() {
-            _result.Denominator
-                .Should().Be(1);
-        }
+    [Test]
+    // German: Der resultierende Bruch sollte 0 als Nenner haben
+    public void The_resulting_fraction_should_have_0_as_denominator() {
+        _result.Denominator
+            .Should().Be(0);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_1_als_Zähler_und_1_als_Nenner_negiert_wird : Spec {
-        private Fraction _result;
+    [Test]
+    // German: Der Bruch sollte 0 sein
+    public void The_fraction_should_be_0() {
+        _result.IsZero
+            .Should().BeTrue();
+    }
+}
 
-        public override void Act() {
-            _result = new Fraction(1, 1, false).Invert();
-        }
+[TestFixture]
+// German: Wenn ein Bruch mit 0 als Zähler und 4 als Nenner negiert wird
+public class When_negating_a_fraction_with_0_as_numerator_and_4_as_denominator : Spec {
+    private Fraction _result;
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_minus_1_als_Zähler_haben() {
-            _result.Numerator
-                .Should().Be(-1);
-        }
+    public override void Act() {
+        _result = new Fraction(0, 4, false).Invert();
+    }
 
-        [Test]
-        public void Soll_der_resultierende_Bruch_1_als_Nenner_haben() {
-            _result.Denominator
-                .Should().Be(1);
-        }
+    [Test]
+    // German: Der resultierende Bruch sollte 0 als Zähler haben
+    public void The_resulting_fraction_should_have_0_as_numerator() {
+        _result.Numerator
+            .Should().Be(0);
+    }
+
+    [Test]
+    // German: Der resultierende Bruch sollte 0 als Nenner haben
+    public void The_resulting_fraction_should_have_0_as_denominator() {
+        _result.Denominator
+            .Should().Be(0);
+    }
+
+    [Test]
+    // German: Der Bruch sollte 0 sein
+    public void The_fraction_should_be_0() {
+        _result.IsZero
+            .Should().BeTrue();
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit minus 1 als Zähler und 1 als Nenner negiert wird
+public class When_negating_a_fraction_with_minus_1_as_numerator_and_1_as_denominator : Spec {
+    private Fraction _result;
+
+    public override void Act() {
+        _result = new Fraction(-1, 1, false).Invert();
+    }
+
+    [Test]
+    // German: Der resultierende Bruch sollte 1 als Zähler haben
+    public void The_resulting_fraction_should_have_1_as_numerator() {
+        _result.Numerator
+            .Should().Be(1);
+    }
+
+    [Test]
+    // German: Der resultierende Bruch sollte 1 als Nenner haben
+    public void The_resulting_fraction_should_have_1_as_denominator() {
+        _result.Denominator
+            .Should().Be(1);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit 1 als Zähler und 1 als Nenner negiert wird
+public class When_negating_a_fraction_with_1_as_numerator_and_1_as_denominator : Spec {
+    private Fraction _result;
+
+    public override void Act() {
+        _result = new Fraction(1, 1, false).Invert();
+    }
+
+    [Test]
+    // German: Der resultierende Bruch sollte minus 1 als Zähler haben
+    public void The_resulting_fraction_should_have_minus_1_as_numerator() {
+        _result.Numerator
+            .Should().Be(-1);
+    }
+
+    [Test]
+    // German: Der resultierende Bruch sollte 1 als Nenner haben
+    public void The_resulting_fraction_should_have_1_as_denominator() {
+        _result.Denominator
+            .Should().Be(1);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Multiply/Method_Multiply.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Multiply/Method_Multiply.cs
@@ -2,116 +2,129 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Multiply {
-    [TestFixture]
-    public class Wenn_0_mit_0_multipliziert_wird : Spec {
-        private Fraction _result;
+namespace Fractions.Tests.FractionSpecs.Multiply;
 
-        public override void Act() {
-            _result = Fraction.Zero.Multiply(Fraction.Zero);
-        }
+[TestFixture]
+// German: Wenn 0 mit 0 multipliziert wird
+public class When_multiplying_0_by_0 : Spec {
+    private Fraction _result;
 
-        [Test]
-        public void Soll_das_Ergebnis_wieder_0_sein() {
-            _result.Should().Be(Fraction.Zero);
-        }
+    public override void Act() {
+        _result = Fraction.Zero.Multiply(Fraction.Zero);
     }
 
-    [TestFixture]
-    public class Wenn_1_mit_0_multipliziert_wird : Spec {
-        private Fraction _result1;
-        private Fraction _result2;
+    [Test]
+    // German: Das Ergebnis sollte wieder 0 sein
+    public void The_result_should_be_0_again() {
+        _result.Should().Be(Fraction.Zero);
+    }
+}
 
-        public override void Act() {
-            _result1 = Fraction.One.Multiply(Fraction.Zero);
-            _result2 = Fraction.Zero.Multiply(Fraction.One);
-        }
+[TestFixture]
+// German: Wenn 1 mit 0 multipliziert wird
+public class When_multiplying_1_by_0 : Spec {
+    private Fraction _result1;
+    private Fraction _result2;
 
-        [Test]
-        public void Soll_das_Ergebnis_wieder_0_sein() {
-            _result1.Should().Be(Fraction.Zero);
-        }
-
-        [Test]
-        public void Soll_die_Operation_kommutativ_sein() {
-            _result1.Should().Be(_result2);
-        }
+    public override void Act() {
+        _result1 = Fraction.One.Multiply(Fraction.Zero);
+        _result2 = Fraction.Zero.Multiply(Fraction.One);
     }
 
-    [TestFixture]
-    public class Wenn_ein_Fünftel_mit_ein_Fünftel_multipliziert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(1, 5);
-            _b = new Fraction(1, 5);
-        }
-
-        public override void Act() {
-            _result = _a.Multiply(_b);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_ein_Fünfundzwanzigstel_sein() {
-            _result.Should().Be(new Fraction(1, 25));
-        }
+    [Test]
+    // German: Das Ergebnis sollte wieder 0 sein
+    public void The_result_should_be_0_again() {
+        _result1.Should().Be(Fraction.Zero);
     }
 
-    [TestFixture]
-    public class Wenn_2_mit_2_Viertel_multipliziert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result1;
-        private Fraction _result2;
+    [Test]
+    // German: Die Operation sollte kommutativ sein
+    public void The_operation_should_be_commutative() {
+        _result1.Should().Be(_result2);
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(2, 1, false);
-            _b = new Fraction(2, 4, false);
-        }
+[TestFixture]
+// German: Wenn ein Fünftel mit ein Fünftel multipliziert wird
+public class When_multiplying_one_fifth_by_one_fifth : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result1 = _a.Multiply(_b);
-            _result2 = _b.Multiply(_a);
-        }
-
-        [Test]
-        public void Soll_das_Ergebnis_1_sein() {
-            _result1.Should().Be(Fraction.One);
-        }
-
-        [Test]
-        public void Soll_die_Operation_kommutativ_sein() {
-            _result1.Should().Be(_result2);
-        }
+    public override void SetUp() {
+        _a = new Fraction(1, 5);
+        _b = new Fraction(1, 5);
     }
 
-    [TestFixture]
-    public class Wenn_minus_2_mit_2_Viertel_multipliziert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result1;
-        private Fraction _result2;
+    public override void Act() {
+        _result = _a.Multiply(_b);
+    }
 
-        public override void SetUp() {
-            _a = new Fraction(-2, 1, false);
-            _b = new Fraction(2, 4, false);
-        }
+    [Test]
+    // German: Das Ergebnis sollte ein Fünfundzwanzigstel sein
+    public void The_result_should_be_one_twenty_fifth() {
+        _result.Should().Be(new Fraction(1, 25));
+    }
+}
 
-        public override void Act() {
-            _result1 = _a.Multiply(_b);
-            _result2 = _b.Multiply(_a);
-        }
+[TestFixture]
+// German: Wenn 2 mit 2 Viertel multipliziert wird
+public class When_multiplying_2_by_2_quarters : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result1;
+    private Fraction _result2;
 
-        [Test]
-        public void Soll_das_Ergebnis_minus_1_sein() {
-            _result1.Should().Be(Fraction.MinusOne);
-        }
+    public override void SetUp() {
+        _a = new Fraction(2, 1, false);
+        _b = new Fraction(2, 4, false);
+    }
 
-        [Test]
-        public void Soll_die_Operation_kommutativ_sein() {
-            _result1.Should().Be(_result2);
-        }
+    public override void Act() {
+        _result1 = _a.Multiply(_b);
+        _result2 = _b.Multiply(_a);
+    }
+
+    [Test]
+    // German: Das Ergebnis sollte 1 sein
+    public void The_result_should_be_1() {
+        _result1.Should().Be(Fraction.One);
+    }
+
+    [Test]
+    // German: Die Operation sollte kommutativ sein
+    public void The_operation_should_be_commutative() {
+        _result1.Should().Be(_result2);
+    }
+}
+
+[TestFixture]
+// German: Wenn minus 2 mit 2 Viertel multipliziert wird
+public class When_multiplying_minus_2_by_2_quarters : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result1;
+    private Fraction _result2;
+
+    public override void SetUp() {
+        _a = new Fraction(-2, 1, false);
+        _b = new Fraction(2, 4, false);
+    }
+
+    public override void Act() {
+        _result1 = _a.Multiply(_b);
+        _result2 = _b.Multiply(_a);
+    }
+
+    [Test]
+    // German: Das Ergebnis sollte minus 1 sein
+    public void The_result_should_be_minus_1() {
+        _result1.Should().Be(Fraction.MinusOne);
+    }
+
+    [Test]
+    // German: Die Operation sollte kommutativ sein
+    public void The_operation_should_be_commutative() {
+        _result1.Should().Be(_result2);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Pow/Method_Pow.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Pow/Method_Pow.cs
@@ -2,38 +2,34 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Pow {
-    [TestFixture]
-    public class Wenn_an_einem_Bruch_die_Potenz_angewendet_wird : Spec {
-        private static IEnumerable TestCases {
-            get {
-                yield return new TestCaseData(new Fraction(1, 3), 2)
-                    .Returns(new Fraction(1, 9));
+namespace Fractions.Tests.FractionSpecs.Pow;
 
-                yield return new TestCaseData(new Fraction(3), -1)
-                    .Returns(new Fraction(1, 3));
-
-                yield return new TestCaseData(new Fraction(3), 0)
-                    .Returns(new Fraction(1));
-
-                yield return new TestCaseData(new Fraction(0), 0)
-                    .Returns(new Fraction(1));
-
-                yield return new TestCaseData(new Fraction(3), 2)
-                    .Returns(new Fraction(9));
-
-                yield return new TestCaseData(new Fraction(3), 3)
-                    .Returns(new Fraction(27));
-
-                yield return new TestCaseData(new Fraction(3), -2)
-                    .Returns(new Fraction(1, 9));
-
-            }
+[TestFixture]
+// German: Wenn an einem Bruch die Potenz angewendet wird
+public class When_exponentiation_is_applied_to_a_fraction : Spec {
+    private static IEnumerable TestCases {
+        get {
+            yield return new TestCaseData(new Fraction(1, 3), 2)
+                .Returns(new Fraction(1, 9));
+            yield return new TestCaseData(new Fraction(3), -1)
+                .Returns(new Fraction(1, 3));
+            yield return new TestCaseData(new Fraction(3), 0)
+                .Returns(new Fraction(1));
+            yield return new TestCaseData(new Fraction(0), 0)
+                .Returns(new Fraction(1));
+            yield return new TestCaseData(new Fraction(3), 2)
+                .Returns(new Fraction(9));
+            yield return new TestCaseData(new Fraction(3), 3)
+                .Returns(new Fraction(27));
+            yield return new TestCaseData(new Fraction(3), -2)
+                .Returns(new Fraction(1, 9));
         }
+    }
 
-        [Test, TestCaseSource(nameof(TestCases))]
-        public Fraction Soll_das_Ergebnis_korrekt_sein(Fraction bruch, int potenz) {
-            return Fraction.Pow(bruch, potenz);
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    // German: Das Ergebnis sollte korrekt sein
+    public Fraction The_result_should_be_correct(Fraction fraction, int power) {
+        return Fraction.Pow(fraction, power);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Reciprocal/Method_Reciprocal.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Reciprocal/Method_Reciprocal.cs
@@ -2,38 +2,42 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Reciprocal {
-    [TestFixture]
-    public class When_natural_number_is_reciprocated : Spec {
-        private Fraction _result1;
-        private Fraction _result2;
-        private Fraction _result3;
+namespace Fractions.Tests.FractionSpecs.Reciprocal;
 
-        public override void Act() {
-            _result1 = Fraction.One.Reciprocal();
-            _result2 = new Fraction(2).Reciprocal();
-            _result3 = new Fraction(17).Reciprocal();
-        }
+[TestFixture]
+// German: Wenn eine natürliche Zahl reziprokiert wird
+public class When_a_natural_number_is_reciprocated : Spec {
+    private Fraction _result1;
+    private Fraction _result2;
+    private Fraction _result3;
 
-        [Test]
-        public void Should_be_1_over_number() {
-            _result1.Should().Be(Fraction.One);
-            _result2.Should().Be(new Fraction(1, 2));
-            _result3.Should().Be(new Fraction(1, 17));
-        }
+    public override void Act() {
+        _result1 = Fraction.One.Reciprocal();
+        _result2 = new Fraction(2).Reciprocal();
+        _result3 = new Fraction(17).Reciprocal();
     }
 
-    [TestFixture]
-    public class When_improper_fraction_is_reciprocated : Spec {
-        private Fraction _result;
+    [Test]
+    // German: Sollte 1 über der Zahl sein
+    public void Should_be_1_over_the_number() {
+        _result1.Should().Be(Fraction.One);
+        _result2.Should().Be(new Fraction(1, 2));
+        _result3.Should().Be(new Fraction(1, 17));
+    }
+}
 
-        public override void Act() {
-            _result = new Fraction(4, 8, false).Reciprocal();
-        }
+[TestFixture]
+// German: Wenn ein unechter Bruch reziprokiert wird
+public class When_an_improper_fraction_is_reciprocated : Spec {
+    private Fraction _result;
 
-        [Test]
-        public void Should_still_be_improper() {
-            _result.Should().Be(new Fraction(8, 4, false));
-        }
+    public override void Act() {
+        _result = new Fraction(4, 8, false).Reciprocal();
+    }
+
+    [Test]
+    // German: Sollte immer noch unecht sein
+    public void Should_still_be_improper() {
+        _result.Should().Be(new Fraction(8, 4, false));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Remainder/Method_Remainder.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Remainder/Method_Remainder.cs
@@ -3,277 +3,303 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Remainder {
-    [TestFixture]
-    public class Wenn_1_Mod_3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+namespace Fractions.Tests.FractionSpecs.Remainder;
 
-        public override void SetUp() {
-            _a = new Fraction(1);
-            _b = new Fraction(3);
-        }
+[TestFixture]
+// German: Wenn 1 Mod 3 errechnet wird
+public class When_calculating_1_mod_3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_1_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(1));
-        }
+    public override void SetUp() {
+        _a = new Fraction(1);
+        _b = new Fraction(3);
     }
 
-    [TestFixture]
-    public class Wenn_0_Mod_3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(0);
-            _b = new Fraction(3);
-        }
-
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_0_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(0));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
     }
 
-    [TestFixture]
-    public class Wenn_4_Mod_3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Soll 1 als Ergebnis zurückgeliefert werden
+    public void Should_return_1_as_the_result() {
+        _result.Should().Be(new Fraction(1));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(4);
-            _b = new Fraction(3);
-        }
+[TestFixture]
+// German: Wenn 0 Mod 3 errechnet wird
+public class When_calculating_0_mod_3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_1_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(1));
-        }
+    public override void SetUp() {
+        _a = new Fraction(0);
+        _b = new Fraction(3);
     }
 
-    [TestFixture]
-    public class Wenn_5_Mod_3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(5);
-            _b = new Fraction(3);
-        }
-
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_2_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(2));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
     }
 
-    [TestFixture]
-    public class Wenn_minus5_Mod_3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Soll 0 als Ergebnis zurückgeliefert werden
+    public void Should_return_0_as_the_result() {
+        _result.Should().Be(new Fraction(0));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(-5);
-            _b = new Fraction(3);
-        }
+[TestFixture]
+// German: Wenn 4 Mod 3 errechnet wird
+public class When_calculating_4_mod_3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_minus2_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(-2));
-        }
+    public override void SetUp() {
+        _a = new Fraction(4);
+        _b = new Fraction(3);
     }
 
-    [TestFixture]
-    public class Wenn_minus5_Mod_minus3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(-5);
-            _b = new Fraction(-3);
-        }
-
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_minus2_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(-2));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
     }
 
-    [TestFixture]
-    public class Wenn_5_Mod_minus3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Soll 1 als Ergebnis zurückgeliefert werden
+    public void Should_return_1_as_the_result() {
+        _result.Should().Be(new Fraction(1));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(5);
-            _b = new Fraction(-3);
-        }
+[TestFixture]
+// German: Wenn 5 Mod 3 errechnet wird
+public class When_calculating_5_mod_3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_2_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(2));
-        }
+    public override void SetUp() {
+        _a = new Fraction(5);
+        _b = new Fraction(3);
     }
 
-    [TestFixture]
-    public class Wenn_6_Mod_3_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(6);
-            _b = new Fraction(3);
-        }
-
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_0_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(0));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
     }
 
-    [TestFixture]
-    public class Wenn_6_Mod_0_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Exception _exception;
+    [Test]
+    // German: Soll 2 als Ergebnis zurückgeliefert werden
+    public void Should_return_2_as_the_result() {
+        _result.Should().Be(new Fraction(2));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(6);
-            _b = new Fraction(0);
-        }
+[TestFixture]
+// German: Wenn minus5 Mod 3 errechnet wird
+public class When_calculating_minus5_mod_3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _exception = Catch.Exception(() => _a.Remainder(_b));
-        }
-
-        [Test]
-        public void Soll_eine_Division_durch_0_Exception_ausgelöst_werden() {
-            _exception.Should().BeOfType<DivideByZeroException>();
-        }
+    public override void SetUp() {
+        _a = new Fraction(-5);
+        _b = new Fraction(3);
     }
 
-    [TestFixture]
-    public class Wenn_2_komma5_Mod_0_komma5_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(5, 2);
-            _b = new Fraction(1, 2);
-        }
-
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_0_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(0));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
     }
 
-    [TestFixture]
-    public class Wenn_2_komma3_Mod_0_komma5_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Soll minus2 als Ergebnis zurückgeliefert werden
+    public void Should_return_minus2_as_the_result() {
+        _result.Should().Be(new Fraction(-2));
+    }
+}
 
-        public override void SetUp() {
-            _a = new Fraction(23, 10);
-            _b = new Fraction(1, 2);
-        }
+[TestFixture]
+// German: Wenn minus5 Mod minus3 errechnet wird
+public class When_calculating_minus5_mod_minus3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Remainder(_b);
-        }
-
-        [Test]
-        public void Soll_0_3_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(3, 10));
-        }
+    public override void SetUp() {
+        _a = new Fraction(-5);
+        _b = new Fraction(-3);
     }
 
-    [TestFixture]
-    public class Wenn_131_Mod_320_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = 131;
-            _b = 320;
-        }
-
-        public override void Act() {
-            _result = _a % _b;
-        }
-
-        [Test]
-        public void Soll_131_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(131));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
     }
 
-    [TestFixture]
-    public class Wenn_60_Mod_100_errechnet_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Soll minus2 als Ergebnis zurückgeliefert werden
+    public void Should_return_minus2_as_the_result() {
+        _result.Should().Be(new Fraction(-2));
+    }
+}
 
-        public override void SetUp() {
-            _a = 60;
-            _b = 100;
-        }
+[TestFixture]
+// German: Wenn 5 Mod minus3 errechnet wird
+public class When_calculating_5_mod_minus3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a % _b;
-        }
+    public override void SetUp() {
+        _a = new Fraction(5);
+        _b = new Fraction(-3);
+    }
 
-        [Test]
-        public void Soll_60_als_Ergebnis_zurückgeliefert_werden() {
-            _result.Should().Be(new Fraction(60));
-        }
+    public override void Act() {
+        _result = _a.Remainder(_b);
+    }
+
+    [Test]
+    // German: Soll 2 als Ergebnis zurückgeliefert werden
+    public void Should_return_2_as_the_result() {
+        _result.Should().Be(new Fraction(2));
+    }
+}
+
+[TestFixture]
+// German: Wenn 6 Mod 3 errechnet wird
+public class When_calculating_6_mod_3 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = new Fraction(6);
+        _b = new Fraction(3);
+    }
+
+    public override void Act() {
+        _result = _a.Remainder(_b);
+    }
+
+    [Test]
+    // German: Soll 0 als Ergebnis zurückgeliefert werden
+    public void Should_return_0_as_the_result() {
+        _result.Should().Be(new Fraction(0));
+    }
+}
+
+[TestFixture]
+// German: Wenn 6 Mod 0 errechnet wird
+public class When_calculating_6_mod_0 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Exception _exception;
+
+    public override void SetUp() {
+        _a = new Fraction(6);
+        _b = new Fraction(0);
+    }
+
+    public override void Act() {
+        _exception = Catch.Exception(() => _a.Remainder(_b));
+    }
+
+    [Test]
+    // German: Soll eine Division durch 0 Exception ausgelöst werden
+    public void Should_throw_a_division_by_zero_exception() {
+        _exception.Should().BeOfType<DivideByZeroException>();
+    }
+}
+
+[TestFixture]
+// German: Wenn 2,5 Mod 0,5 errechnet wird
+public class When_calculating_2_point_5_mod_0_point_5 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = new Fraction(5, 2);
+        _b = new Fraction(1, 2);
+    }
+
+    public override void Act() {
+        _result = _a.Remainder(_b);
+    }
+
+    [Test]
+    // German: Soll 0 als Ergebnis zurückgeliefert werden
+    public void Should_return_0_as_the_result() {
+        _result.Should().Be(new Fraction(0));
+    }
+}
+
+[TestFixture]
+// German: Wenn 2,3 Mod 0,5 errechnet wird
+public class When_calculating_2_point_3_mod_0_point_5 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = new Fraction(23, 10);
+        _b = new Fraction(1, 2);
+    }
+
+    public override void Act() {
+        _result = _a.Remainder(_b);
+    }
+
+    [Test]
+    // German: Soll 0,3 als Ergebnis zurückgeliefert werden
+    public void Should_return_0_point_3_as_the_result() {
+        _result.Should().Be(new Fraction(3, 10));
+    }
+}
+
+[TestFixture]
+// German: Wenn 131 Mod 320 errechnet wird
+public class When_calculating_131_mod_320 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = 131;
+        _b = 320;
+    }
+
+    public override void Act() {
+        _result = _a % _b;
+    }
+
+    [Test]
+    // German: Soll 131 als Ergebnis zurückgeliefert werden
+    public void Should_return_131_as_the_result() {
+        _result.Should().Be(new Fraction(131));
+    }
+}
+
+[TestFixture]
+// German: Wenn 60 Mod 100 errechnet wird
+public class When_calculating_60_mod_100 : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = 60;
+        _b = 100;
+    }
+
+    public override void Act() {
+        _result = _a % _b;
+    }
+
+    [Test]
+    // German: Soll 60 als Ergebnis zurückgeliefert werden
+    public void Should_return_60_as_the_result() {
+        _result.Should().Be(new Fraction(60));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Sqrt/Method_Sqrt.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Sqrt/Method_Sqrt.cs
@@ -4,41 +4,39 @@ using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Sqrt {
+namespace Fractions.Tests.FractionSpecs.Sqrt;
 
-    [TestFixture]
-    public class If_the_Sqrt_function_is_called : Spec {
-        [Test]
-        public void Sqrt_Of_1_Shall_Be_1() {
-            Fraction.One.Sqrt()
-                .Should().Be(1);
+[TestFixture]
+public class If_the_Sqrt_function_is_called : Spec {
+    [Test]
+    public void The_square_root_of_1_should_be_1() {
+        Fraction.One.Sqrt()
+            .Should().Be(1);
+    }
+
+    [Test]
+    public void The_square_root_of_minus_one_should_fail() {
+        Action act = () => Fraction.MinusOne.Sqrt();
+        act.Should().Throw<OverflowException>()
+            .WithMessage("Cannot calculate square root from a negative number");
+    }
+
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(0.001);
+            yield return new TestCaseData(5);
+            yield return new TestCaseData(4.54854751);
+            yield return new TestCaseData(9999999855487);
+            yield return new TestCaseData(99999998554865557);
+            yield return new TestCaseData(Math.PI);
         }
+    }
 
-        [Test]
-        public void Sqrt_Of_MinusOne_Shall_Be_Fail() {
-
-            Action act = () => Fraction.MinusOne.Sqrt();
-
-            act.Should().Throw<OverflowException>()
-                        .WithMessage("Cannot calculate square root from a negative number");
-        }
-
-        private static IEnumerable<TestCaseData> TestCases {
-            get {
-                yield return new TestCaseData(0.001);
-                yield return new TestCaseData(5);
-                yield return new TestCaseData(4.54854751);
-                yield return new TestCaseData(9999999855487);
-                yield return new TestCaseData(99999998554865557);
-                yield return new TestCaseData(Math.PI);
-            }
-        }
-
-        [Test,TestCaseSource(nameof(TestCases))]
-        public void Should_the_result_be_equal_to_Math_Sqrt(double value) {
-            var expected = Math.Sqrt(value);
-            var actual = Fraction.FromDouble(value).Sqrt();
-            actual.ToDouble().Should().Be(expected);
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void The_result_should_be_equal_to_Math_Sqrt(double value) {
+        var expected = Math.Sqrt(value);
+        var actual = Fraction.FromDouble(value).Sqrt();
+        actual.ToDouble().Should().Be(expected);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Subtract/Method_Subtract.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Subtract/Method_Subtract.cs
@@ -2,87 +2,97 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.Subtract {
-    [TestFixture]
-    public class Wenn_2_Fünftel_mit_1_Fünftel_subtrahiert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+namespace Fractions.Tests.FractionSpecs.Subtract;
 
-        public override void SetUp() {
-            _a = new Fraction(2, 5);
-            _b = new Fraction(1, 5);
-        }
+[TestFixture]
+// German: Wenn 2 Fünftel mit 1 Fünftel subtrahiert wird
+public class When_subtracting_2_fifths_by_1_fifth : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        public override void Act() {
-            _result = _a.Subtract(_b);
-        }
-
-        [Test]
-        public void Soll_der_Zähler_im_Ergebnis_1_sein() {
-            _result.Numerator.Should().Be(1);
-        }
-
-        [Test]
-        public void Soll_der_Nenner_im_Ergebnis_5_sein() {
-            _result.Denominator.Should().Be(5);
-        }
+    public override void SetUp() {
+        _a = new Fraction(2, 5);
+        _b = new Fraction(1, 5);
     }
 
-    [TestFixture]
-    public class Wenn_1_Fünftel_mit_2_Fünftel_subtrahiert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
-
-        public override void SetUp() {
-            _a = new Fraction(1, 5);
-            _b = new Fraction(2, 5);
-        }
-
-        public override void Act() {
-            _result = _a.Subtract(_b);
-        }
-
-        [Test]
-        public void Soll_der_Zähler_im_Ergebnis_minus_1_sein() {
-            _result.Numerator.Should().Be(-1);
-        }
-
-        [Test]
-        public void Soll_der_Nenner_im_Ergebnis_5_sein() {
-            _result.Denominator.Should().Be(5);
-        }
+    public override void Act() {
+        _result = _a.Subtract(_b);
     }
 
-    [TestFixture]
-    public class Wenn_1_Fünftel_mit_1_Fünftel_subtrahiert_wird : Spec {
-        private Fraction _a;
-        private Fraction _b;
-        private Fraction _result;
+    [Test]
+    // German: Soll der Zähler im Ergebnis 1 sein
+    public void The_numerator_in_the_result_should_be_1() {
+        _result.Numerator.Should().Be(1);
+    }
 
-        public override void SetUp() {
-            _a = new Fraction(1, 5);
-            _b = new Fraction(1, 5);
-        }
+    [Test]
+    // German: Soll der Nenner im Ergebnis 5 sein
+    public void The_denominator_in_the_result_should_be_5() {
+        _result.Denominator.Should().Be(5);
+    }
+}
 
-        public override void Act() {
-            _result = _a.Subtract(_b);
-        }
+[TestFixture]
+// German: Wenn 1 Fünftel mit 2 Fünftel subtrahiert wird
+public class When_subtracting_1_fifth_by_2_fifths : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
 
-        [Test]
-        public void Soll_der_Zähler_im_Ergebnis_0_sein() {
-            _result.Numerator.Should().Be(0);
-        }
+    public override void SetUp() {
+        _a = new Fraction(1, 5);
+        _b = new Fraction(2, 5);
+    }
 
-        [Test]
-        public void Soll_der_Nenner_im_Ergebnis_0_sein() {
-            _result.Denominator.Should().Be(0);
-        }
+    public override void Act() {
+        _result = _a.Subtract(_b);
+    }
 
-        [Test]
-        public void Soll_der_Wert_des_Bruches_als_Null_erkannt_werden() {
-            _result.IsZero.Should().BeTrue();
-        }
+    [Test]
+    // German: Soll der Zähler im Ergebnis minus 1 sein
+    public void The_numerator_in_the_result_should_be_minus_1() {
+        _result.Numerator.Should().Be(-1);
+    }
+
+    [Test]
+    // German: Soll der Nenner im Ergebnis 5 sein
+    public void The_denominator_in_the_result_should_be_5() {
+        _result.Denominator.Should().Be(5);
+    }
+}
+
+[TestFixture]
+// German: Wenn 1 Fünftel mit 1 Fünftel subtrahiert wird
+public class When_subtracting_1_fifth_by_1_fifth : Spec {
+    private Fraction _a;
+    private Fraction _b;
+    private Fraction _result;
+
+    public override void SetUp() {
+        _a = new Fraction(1, 5);
+        _b = new Fraction(1, 5);
+    }
+
+    public override void Act() {
+        _result = _a.Subtract(_b);
+    }
+
+    [Test]
+    // German: Soll der Zähler im Ergebnis 0 sein
+    public void The_numerator_in_the_result_should_be_0() {
+        _result.Numerator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der Nenner im Ergebnis 0 sein
+    public void The_denominator_in_the_result_should_be_0() {
+        _result.Denominator.Should().Be(0);
+    }
+
+    [Test]
+    // German: Soll der Wert des Bruches als Null erkannt werden
+    public void The_value_of_the_fraction_should_be_recognized_as_zero() {
+        _result.IsZero.Should().BeTrue();
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/ToDataType/Method_ToDataType.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ToDataType/Method_ToDataType.cs
@@ -1,81 +1,89 @@
-using System;
+Ôªøusing System;
 using System.Collections;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.ToDataType {
-    [TestFixture]
-    public class Wenn_ein_0_Bruch_in_ein_Decimal_konvertiert_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_0_sein() {
-            Fraction.Zero.ToDecimal().Should().Be(0);
+namespace Fractions.Tests.FractionSpecs.ToDataType;
+
+[TestFixture]
+// German: Wenn ein 0 Bruch in ein Decimal konvertiert wird
+public class When_zero_fraction_is_converted_to_decimal : Spec {
+    [Test]
+    // German: Das Ergebnis soll 0 sein
+    public void Result_should_be_zero() {
+        Fraction.Zero.ToDecimal().Should().Be(0);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein 1viertel in ein Decimal konvertiert wird
+public class When_one_quarter_is_converted_to_decimal : Spec {
+    [Test]
+    // German: Das Ergebnis soll 0.25 sein
+    public void Result_should_be_0_25() {
+        new Fraction(1, 4).ToDecimal().Should().Be(0.25m);
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit long MaxValue von Fraction in int konvertiert wird
+public class When_fraction_with_long_MaxValue_is_converted_to_int : Spec {
+    [Test]
+    // German: Das sollte eine OverflowException werfen
+    public void Should_throw_an_OverflowException() {
+        Invoking(() => new Fraction(long.MaxValue).ToInt32())
+            .Should()
+            .Throw<OverflowException>();
+    }
+}
+
+[TestFixture]
+// German: Wenn ein Bruch mit sehr gro√üen Zahlen in Z√§hler und Nenner in ein Decimal konvertiert wird
+public class When_fraction_with_large_numerator_and_denominator_is_converted_to_decimal : Spec {
+    private Fraction _fraction;
+    private decimal _result;
+
+    public override void SetUp() {
+        var threeNinths = new Fraction(3, 9).ToDecimal();
+        var sixNinths = new Fraction(6, 9).ToDecimal();
+        _fraction = new Fraction(threeNinths) * new Fraction(sixNinths);
+    }
+
+    public override void Act() {
+        _result = _fraction.ToDecimal();
+    }
+
+    [Test]
+    // German: Das Resultat soll dem erwarteten Ergebnis entsprechen
+    public void Result_should_match_expected_value() {
+        Math.Round(_result, 27).Should().Be(0.222222222222222222222222222m);
+    }
+}
+
+[TestFixture]
+public class When_user_converts_fraction_to_BigInteger : Spec {
+    private static IEnumerable TestCases {
+        get {
+            yield return new TestCaseData(new Fraction(0)).Returns(new BigInteger(0));
+            yield return new TestCaseData(new Fraction(1)).Returns(new BigInteger(1));
+            yield return new TestCaseData(new Fraction(-1)).Returns(new BigInteger(-1));
+            yield return
+                new TestCaseData(new Fraction(new BigInteger(long.MaxValue), new BigInteger(1))).Returns(
+                    new BigInteger(long.MaxValue));
         }
     }
 
-    [TestFixture]
-    public class Wenn_ein_1viertel_in_ein_Decimal_konvertiert_wird : Spec {
-        [Test]
-        public void Soll_das_Ergebnis_0_25_sein() {
-            new Fraction(1, 4).ToDecimal().Should().Be(0.25m);
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public BigInteger Result_should_be_correct(Fraction value) {
+        return value.ToBigInteger();
     }
 
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_long_MaxValue_von_Fraction_in_int_konvertiert_wird : Spec
-    {
-        [Test]
-        public void Soll_das_eine_OverflowException_werfen() {
-            Invoking(() => new Fraction(long.MaxValue).ToInt32())
-                .Should()
-                .Throw<OverflowException>();
-        }
-    }
-
-    [TestFixture]
-    public class Wenn_ein_Bruch_mit_sehr_groﬂen_Zahlen_in_Z‰hler_und_Nenner_in_ein_Decimal_konvertiert_wird : Spec {
-        private Fraction _fraction;
-        private decimal _result;
-
-        public override void SetUp() {
-            var dreiDurch9 = new Fraction(3, 9).ToDecimal();
-            var sechsDurch9 = new Fraction(6, 9).ToDecimal();
-            _fraction = new Fraction(dreiDurch9) * new Fraction(sechsDurch9);
-        }
-
-        public override void Act() {
-            _result = _fraction.ToDecimal();
-        }
-
-        [Test]
-        public void Soll_das_Resultat_dem_erwarteten_Ergebnis_entsprechen() {
-            Math.Round(_result, 27).Should().Be(0.222222222222222222222222222m);
-        }
-    }
-
-    [TestFixture]
-    public class If_the_user_converts_a_fraction_to_BigInteger : Spec {
-        private static IEnumerable TestCases {
-            get {
-                yield return new TestCaseData(new Fraction(0)).Returns(new BigInteger(0));
-                yield return new TestCaseData(new Fraction(1)).Returns(new BigInteger(1));
-                yield return new TestCaseData(new Fraction(-1)).Returns(new BigInteger(-1));
-                yield return
-                    new TestCaseData(new Fraction(new BigInteger(long.MaxValue), new BigInteger(1))).Returns(
-                        new BigInteger(long.MaxValue));
-            }
-        }
-
-        [Test, TestCaseSource(nameof(TestCases))]
-        public BigInteger Shall_the_result_be_correct(Fraction value) {
-            return value.ToBigInteger();
-        }
-
-        [Test, TestCaseSource(nameof(TestCases))]
-        public BigInteger Shall_the_result_be_correct_when_using_explicit_cast(Fraction value) {
-            return (BigInteger) value;
-        }
-
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public BigInteger Result_should_be_correct_when_using_explicit_cast(Fraction value) {
+        return (BigInteger)value;
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/ToString/Method_ToString.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ToString/Method_ToString.cs
@@ -5,127 +5,129 @@ using Fractions.Formatter;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.ToString
-{
-    [TestFixture]
-    public class If_the_user_calls_ToString : Spec {
-        private static IEnumerable<TestCaseData> TestCases {
-            get {
-                yield return new TestCaseData(new Fraction(3, 0))
-                    .Returns("0");
-                yield return new TestCaseData(new Fraction(0, 0))
-                    .Returns("0");
-                yield return new TestCaseData(new Fraction(0, 3))
-                    .Returns("0");
-                yield return new TestCaseData(new Fraction(1, 3))
-                    .Returns("1/3");
-                yield return new TestCaseData(new Fraction(-1, 3))
-                    .Returns("-1/3");
-                yield return new TestCaseData(new Fraction(1, -3, false))
-                    .Returns("1/-3");
-                yield return new TestCaseData(new Fraction(-1, -3, false))
-                    .Returns("-1/-3");
-            }
-        }
+namespace Fractions.Tests.FractionSpecs.ToString;
 
-        [Test, TestCaseSource(nameof(TestCases))]
-        public string Shall_the_text_output_be_the_expected_one(Fraction fraction) {
-            return fraction.ToString();
+[TestFixture]
+public class When_the_user_calls_ToString : Spec {
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(new Fraction(3, 0))
+                .Returns("0");
+            yield return new TestCaseData(new Fraction(0, 0))
+                .Returns("0");
+            yield return new TestCaseData(new Fraction(0, 3))
+                .Returns("0");
+            yield return new TestCaseData(new Fraction(1, 3))
+                .Returns("1/3");
+            yield return new TestCaseData(new Fraction(-1, 3))
+                .Returns("-1/3");
+            yield return new TestCaseData(new Fraction(1, -3, false))
+                .Returns("1/-3");
+            yield return new TestCaseData(new Fraction(-1, -3, false))
+                .Returns("-1/-3");
         }
     }
 
-    [TestFixture]
-    public class If_the_user_calls_ToString_using_a_format_string : Spec {
-        private static IEnumerable<TestCaseData> TestCases {
-            get {
-                var de = new CultureInfo("de-DE");
-                var en = new CultureInfo("en-US");
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public string The_text_output_should_be_the_expected_one(Fraction fraction) {
+        return fraction.ToString();
+    }
+}
 
-                yield return new TestCaseData(new Fraction(1, 3), string.Empty, en)
-                    .Returns("1/3");
-                yield return new TestCaseData(new Fraction(1, 3), null, en)
-                    .Returns("1/3");
-                yield return new TestCaseData(Fraction.Zero, null, en)
-                    .Returns("0");
+[TestFixture]
+public class When_the_user_calls_ToString_using_a_format_string : Spec {
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            var de = new CultureInfo("de-DE");
+            var en = new CultureInfo("en-US");
 
-                yield return new TestCaseData(new Fraction(0, 3), "G", de)
-                    .Returns("0");
-                yield return new TestCaseData(new Fraction(1, 3), "G", de)
-                    .Returns("1/3");
-                yield return new TestCaseData(new Fraction(3, 1), "G", de)
-                    .Returns("3");
-                yield return new TestCaseData(new Fraction(1, 3), "G", new DefaultFractionFormatProvider())
-                    .Returns("1/3");
-                yield return new TestCaseData(new Fraction(1, 3), "G", en)
-                    .Returns("1/3");
-                yield return new TestCaseData(new Fraction(-1, 3), "G", en)
-                    .Returns("-1/3");
-                yield return new TestCaseData(new Fraction(1, -3, false), "G", en)
-                    .Returns("1/-3");
-                yield return new TestCaseData(new Fraction(-1, -3, false), "G", en)
-                    .Returns("-1/-3");
-                yield return new TestCaseData(Fraction.Zero, "G", en)
-                    .Returns("0");
+            yield return new TestCaseData(new Fraction(1, 3), string.Empty, en)
+                .Returns("1/3");
+            yield return new TestCaseData(new Fraction(1, 3), null, en)
+                .Returns("1/3");
+            yield return new TestCaseData(Fraction.Zero, null, en)
+                .Returns("0");
 
-                yield return new TestCaseData(new Fraction(-1, -3, false), "n", en)
-                    .Returns("-1");
-                yield return new TestCaseData(new Fraction(3, 1), "n", de)
-                    .Returns("3");
+            yield return new TestCaseData(new Fraction(0, 3), "G", de)
+                .Returns("0");
+            yield return new TestCaseData(new Fraction(1, 3), "G", de)
+                .Returns("1/3");
+            yield return new TestCaseData(new Fraction(3, 1), "G", de)
+                .Returns("3");
+            yield return new TestCaseData(new Fraction(1, 3), "G", new DefaultFractionFormatProvider())
+                .Returns("1/3");
+            yield return new TestCaseData(new Fraction(1, 3), "G", en)
+                .Returns("1/3");
+            yield return new TestCaseData(new Fraction(-1, 3), "G", en)
+                .Returns("-1/3");
+            yield return new TestCaseData(new Fraction(1, -3, false), "G", en)
+                .Returns("1/-3");
+            yield return new TestCaseData(new Fraction(-1, -3, false), "G", en)
+                .Returns("-1/-3");
+            yield return new TestCaseData(Fraction.Zero, "G", en)
+                .Returns("0");
 
-                yield return new TestCaseData(new Fraction(-1, -3, false), "d", en)
-                    .Returns("-3");
-                yield return new TestCaseData(new Fraction(-1, -3, false), "d d", en)
-                    .Returns("-3 -3");
-                yield return new TestCaseData(new Fraction(3, 1), "d", de)
-                    .Returns("1");
-                yield return new TestCaseData(Fraction.Zero, "d", de)
-                    .Returns("0");
+            yield return new TestCaseData(new Fraction(-1, -3, false), "n", en)
+                .Returns("-1");
+            yield return new TestCaseData(new Fraction(3, 1), "n", de)
+                .Returns("3");
 
-                yield return new TestCaseData(new Fraction(1, 3), "n/d", en)
-                    .Returns("1/3");
-                yield return new TestCaseData(Fraction.Zero, "n/d", en)
-                    .Returns("0/0");
+            yield return new TestCaseData(new Fraction(-1, -3, false), "d", en)
+                .Returns("-3");
+            yield return new TestCaseData(new Fraction(-1, -3, false), "d d", en)
+                .Returns("-3 -3");
+            yield return new TestCaseData(new Fraction(3, 1), "d", de)
+                .Returns("1");
+            yield return new TestCaseData(Fraction.Zero, "d", de)
+                .Returns("0");
 
-                yield return new TestCaseData(new Fraction(3, 1), "z", de)
-                    .Returns("3");
-                yield return new TestCaseData(new Fraction(1, 3), "z", de)
-                    .Returns("0");
-                yield return new TestCaseData(new Fraction(1, 2), "z", de)
-                    .Returns("0");
-                yield return new TestCaseData(Fraction.Zero, "z", de)
-                    .Returns("0");
-                yield return new TestCaseData(new Fraction(1, 2), "r", de)
-                    .Returns("1/2");
-                yield return new TestCaseData(new Fraction(1, -2), "r", de)
-                    .Returns("-1/2");
-                yield return new TestCaseData(Fraction.Zero, "r", de)
-                    .Returns("0");
+            yield return new TestCaseData(new Fraction(1, 3), "n/d", en)
+                .Returns("1/3");
+            yield return new TestCaseData(Fraction.Zero, "n/d", en)
+                .Returns("0/0");
 
-                yield return new TestCaseData(new Fraction(3, 2), "m", de)
-                    .Returns("1 1/2");
-                yield return new TestCaseData(new Fraction(-3, 2), "m", de)
-                    .Returns("-1 1/2");
-                yield return new TestCaseData(new Fraction(-1, 2), "m", de)
-                    .Returns("-1/2");
-                yield return new TestCaseData(new Fraction(1, 2), "m", de)
-                    .Returns("1/2");
-                yield return new TestCaseData(new Fraction(2, 1), "m", de)
-                    .Returns("2");
-                yield return new TestCaseData(new Fraction(-2, 1), "m", de)
-                    .Returns("-2");
-                yield return new TestCaseData(Fraction.Zero, "m", de)
-                    .Returns("0");
-            }
+            yield return new TestCaseData(new Fraction(3, 1), "z", de)
+                .Returns("3");
+            yield return new TestCaseData(new Fraction(1, 3), "z", de)
+                .Returns("0");
+            yield return new TestCaseData(new Fraction(1, 2), "z", de)
+                .Returns("0");
+            yield return new TestCaseData(Fraction.Zero, "z", de)
+                .Returns("0");
+            yield return new TestCaseData(new Fraction(1, 2), "r", de)
+                .Returns("1/2");
+            yield return new TestCaseData(new Fraction(1, -2), "r", de)
+                .Returns("-1/2");
+            yield return new TestCaseData(Fraction.Zero, "r", de)
+                .Returns("0");
+
+            yield return new TestCaseData(new Fraction(3, 2), "m", de)
+                .Returns("1 1/2");
+            yield return new TestCaseData(new Fraction(-3, 2), "m", de)
+                .Returns("-1 1/2");
+            yield return new TestCaseData(new Fraction(-1, 2), "m", de)
+                .Returns("-1/2");
+            yield return new TestCaseData(new Fraction(1, 2), "m", de)
+                .Returns("1/2");
+            yield return new TestCaseData(new Fraction(2, 1), "m", de)
+                .Returns("2");
+            yield return new TestCaseData(new Fraction(-2, 1), "m", de)
+                .Returns("-2");
+            yield return new TestCaseData(Fraction.Zero, "m", de)
+                .Returns("0");
         }
+    }
 
-        [Test,TestCaseSource(nameof(TestCases))]
-        public string Shall_the_text_output_be_the_expected_one(Fraction fraction, string format, IFormatProvider cultureInfo) {
-            return fraction.ToString(format, cultureInfo);
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public string The_text_output_should_be_the_expected_one(Fraction fraction, string format, IFormatProvider cultureInfo) {
+        return fraction.ToString(format, cultureInfo);
+    }
 
-        [Test, TestCaseSource(nameof(TestCases))]
-        public string Shall_the_text_output_be_the_expected_one_when_using_the_simple_ToString_method(Fraction fraction, string format, IFormatProvider cultureInfo) {
-            return fraction.ToString(format);
-        }
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public string The_text_output_should_be_the_expected_one_when_using_the_simple_ToString_method(Fraction fraction, string format, IFormatProvider cultureInfo) {
+        return fraction.ToString(format);
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/ValueEquals/Method_ValueEquals.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ValueEquals/Method_ValueEquals.cs
@@ -2,87 +2,91 @@
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.FractionSpecs.ValueEquals {
-    [TestFixture]
-    public class Wenn_zwei_Brüche_mit_identischen_Zähler_und_Nenner_verglichen_werden : Spec {
-        private Fraction _fractionA;
-        private Fraction _fractionB;
+namespace Fractions.Tests.FractionSpecs.ValueEquals;
 
-        public override void SetUp() {
-            base.SetUp();
+[TestFixture]
+// German: Wenn zwei Brüche mit identischen Zähler und Nenner verglichen werden
+public class When_comparing_two_fractions_with_identical_numerator_and_denominator : Spec {
+    private Fraction _fractionA;
+    private Fraction _fractionB;
 
-            _fractionA = new Fraction(5, 6, true);
-            _fractionB = new Fraction(5, 6, true);
-        }
-
-        [Test]
-        public void Sollen_diese_als_Wertgleich_erkannt_werden() {
-            _fractionA.IsEquivalentTo(_fractionB)
-                .Should().BeTrue();
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fractionA = new Fraction(5, 6, true);
+        _fractionB = new Fraction(5, 6, true);
     }
 
-    [TestFixture]
-    public class Wenn_zwei_Brüche_mit_unterschiedlichen_Zähler_aber_identischen_Nenner_verglichen_werden : Spec {
-        private Fraction _fractionA;
-        private Fraction _fractionB;
+    [Test]
+    // German: Diese sollten als wertgleich erkannt werden
+    public void These_should_be_recognized_as_equivalent() {
+        _fractionA.IsEquivalentTo(_fractionB)
+            .Should().BeTrue();
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
+[TestFixture]
+// German: Wenn zwei Brüche mit unterschiedlichen Zähler aber identischen Nenner verglichen werden
+public class When_comparing_two_fractions_with_different_numerator_but_identical_denominator : Spec {
+    private Fraction _fractionA;
+    private Fraction _fractionB;
 
-            _fractionA = new Fraction(4, 6, true);
-            _fractionB = new Fraction(5, 6, true);
-        }
-
-        [Test]
-        public void Sollen_diese_als_nicht_Wertgleich_erkannt_werden() {
-            _fractionA.IsEquivalentTo(_fractionB)
-                .Should().BeFalse();
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fractionA = new Fraction(4, 6, true);
+        _fractionB = new Fraction(5, 6, true);
     }
 
-    [TestFixture]
-    public class Wenn_zwei_Brüche_mit_identischen_Zähler_aber_unterschiedlichen_Nenner_verglichen_werden : Spec {
-        private Fraction _fractionA;
-        private Fraction _fractionB;
+    [Test]
+    // German: Diese sollten als nicht wertgleich erkannt werden
+    public void These_should_be_recognized_as_not_equivalent() {
+        _fractionA.IsEquivalentTo(_fractionB)
+            .Should().BeFalse();
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
+[TestFixture]
+// German: Wenn zwei Brüche mit identischen Zähler aber unterschiedlichen Nenner verglichen werden
+public class When_comparing_two_fractions_with_identical_numerator_but_different_denominator : Spec {
+    private Fraction _fractionA;
+    private Fraction _fractionB;
 
-            _fractionA = new Fraction(4, 6, true);
-            _fractionB = new Fraction(4, 7, true);
-        }
-
-        [Test]
-        public void Sollen_diese_als_nicht_Wertgleich_erkannt_werden() {
-            _fractionA.IsEquivalentTo(_fractionB)
-                .Should().BeFalse();
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fractionA = new Fraction(4, 6, true);
+        _fractionB = new Fraction(4, 7, true);
     }
 
-    [TestFixture]
-    public class Wenn_der_Bruch_2_4_mit_dem_Bruch_1_2_verglichen_wird : Spec {
-        private Fraction _fractionA;
-        private Fraction _fractionB;
+    [Test]
+    // German: Diese sollten als nicht wertgleich erkannt werden
+    public void These_should_be_recognized_as_not_equivalent() {
+        _fractionA.IsEquivalentTo(_fractionB)
+            .Should().BeFalse();
+    }
+}
 
-        public override void SetUp() {
-            base.SetUp();
+[TestFixture]
+// German: Wenn der Bruch 2/4 mit dem Bruch 1/2 verglichen wird
+public class When_comparing_the_fraction_2_over_4_with_the_fraction_1_over_2 : Spec {
+    private Fraction _fractionA;
+    private Fraction _fractionB;
 
-            _fractionA = new Fraction(2, 4, false);
-            _fractionB = new Fraction(1, 2, true);
-        }
+    public override void SetUp() {
+        base.SetUp();
+        _fractionA = new Fraction(2, 4, false);
+        _fractionB = new Fraction(1, 2, true);
+    }
 
+    [Test]
+    // German: Die Brüche sollten als nicht strukturell gleich erkannt werden
+    public void The_fractions_should_be_recognized_as_not_equal() {
+        _fractionA.Equals(_fractionB)
+            .Should().BeFalse();
+    }
 
-        [Test]
-        public void Sollen_die_Brüche_als_nicht_strukturell_gleich_erkannt_werden() {
-            _fractionA.Equals(_fractionB)
-                .Should().BeFalse();
-        }
-
-        [Test]
-        public void Sollen_die_Brüche_als_Wertgleich_erkannt_werden() {
-            _fractionA.IsEquivalentTo(_fractionB)
-                .Should().BeTrue();
-        }
+    [Test]
+    // German: Die Brüche sollten als wertgleich erkannt werden
+    public void The_fractions_should_be_recognized_as_equivalent() {
+        _fractionA.IsEquivalentTo(_fractionB)
+            .Should().BeTrue();
     }
 }

--- a/tests/Fractions.Tests/Spec.cs
+++ b/tests/Fractions.Tests/Spec.cs
@@ -1,30 +1,31 @@
 ﻿using System;
 using NUnit.Framework;
 
-namespace Tests.Fractions {
-    public class Spec {
-        [OneTimeSetUp]
-        public void TestFixtureSetUp() {
-            SetUp();
-            Arrange();
-            Act();
-        }
+namespace Tests.Fractions;
 
-        [OneTimeTearDown]
-        public void TestFixtureTearDown() {
-            TearDown();
-        }
+public class Spec {
+    
+    [OneTimeSetUp]
+    public void TestFixtureSetUp() {
+        SetUp();
+        Arrange();
+        Act();
+    }
 
-        public virtual void SetUp() {}
+    [OneTimeTearDown]
+    public void TestFixtureTearDown() {
+        TearDown();
+    }
 
-        public virtual void TearDown() {}
+    public virtual void SetUp() { }
 
-        public virtual void Arrange() {}
+    public virtual void TearDown() { }
 
-        public virtual void Act() {}
+    public virtual void Arrange() { }
 
-        protected Action Invoking(Action func) {
-            return func;
-        }
+    public virtual void Act() { }
+
+    protected Action Invoking(Action func) {
+        return func;
     }
 }

--- a/tests/Fractions.Tests/TypeConverters/FractionTypeConverterSpecs/ConvertFrom/Method_ConvertFrom.cs
+++ b/tests/Fractions.Tests/TypeConverters/FractionTypeConverterSpecs/ConvertFrom/Method_ConvertFrom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
@@ -7,82 +6,84 @@ using Fractions.TypeConverters;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.TypeConverters.FractionTypeConverterSpecs.ConvertFrom {
-    [TestFixture]
-    public class If_the_user_wants_to_convert_a_type_to_Fraction : Spec {
-        private FractionTypeConverter _converter;
+namespace Fractions.Tests.TypeConverters.FractionTypeConverterSpecs.ConvertFrom;
 
-        public override void SetUp() {
-            _converter = new FractionTypeConverter();
+[TestFixture]
+public class When_converting_a_type_to_Fraction : Spec {
+    private FractionTypeConverter _converter;
+
+    public override void SetUp() {
+        _converter = new FractionTypeConverter();
+    }
+
+    private static IEnumerable<TestCaseData> TypeTests {
+        get {
+            yield return new TestCaseData(typeof(Fraction)).Returns(true);
+            yield return new TestCaseData(typeof(int)).Returns(true);
+            yield return new TestCaseData(typeof(long)).Returns(true);
+            yield return new TestCaseData(typeof(decimal)).Returns(true);
+            yield return new TestCaseData(typeof(double)).Returns(true);
+            yield return new TestCaseData(typeof(string)).Returns(true);
+            yield return new TestCaseData(typeof(BigInteger)).Returns(true);
+
+            yield return new TestCaseData(typeof(bool)).Returns(false);
+            yield return new TestCaseData(typeof(object)).Returns(false);
         }
+    }
 
-        private static IEnumerable<TestCaseData> TypeTests {
-            get {
-                yield return new TestCaseData(typeof (Fraction)).Returns(true);
-                yield return new TestCaseData(typeof (int)).Returns(true);
-                yield return new TestCaseData(typeof (long)).Returns(true);
-                yield return new TestCaseData(typeof (decimal)).Returns(true);
-                yield return new TestCaseData(typeof (double)).Returns(true);
-                yield return new TestCaseData(typeof (string)).Returns(true);
-                yield return new TestCaseData(typeof (BigInteger)).Returns(true);
+    [Test]
+    [TestCaseSource(nameof(TypeTests))]
+    public bool CanConvertFrom_ShouldReturnCorrectResult(Type destinationType) {
+        return _converter.CanConvertFrom(destinationType);
+    }
 
-                yield return new TestCaseData(typeof (bool)).Returns(false);
-                yield return new TestCaseData(typeof (object)).Returns(false);
-            }
+    private static IEnumerable<TestCaseData> ConvertFromTests {
+        get {
+            yield return new TestCaseData(Fraction.One, CultureInfo.CurrentCulture).Returns(Fraction.One);
+            yield return new TestCaseData(new Fraction(1, 2), CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
+
+            yield return new TestCaseData(0, CultureInfo.CurrentCulture).SetName("0 (integer)").Returns(Fraction.Zero);
+            yield return new TestCaseData(1, CultureInfo.CurrentCulture).SetName("1 (integer)").Returns(Fraction.One);
+            yield return new TestCaseData(-1, CultureInfo.CurrentCulture).SetName("-1 (integer)").Returns(new Fraction(-1));
+
+            yield return new TestCaseData(0L, CultureInfo.CurrentCulture).SetName("0 (long)").Returns(Fraction.Zero);
+            yield return new TestCaseData(1L, CultureInfo.CurrentCulture).SetName("1 (long)").Returns(Fraction.One);
+            yield return new TestCaseData(-1L, CultureInfo.CurrentCulture).SetName("-1 (long)").Returns(new Fraction(-1));
+
+            yield return new TestCaseData(BigInteger.Zero, CultureInfo.CurrentCulture).SetName("0 (big integer)").Returns(Fraction.Zero);
+            yield return new TestCaseData(BigInteger.One, CultureInfo.CurrentCulture).SetName("1 (big integer)").Returns(Fraction.One);
+            yield return new TestCaseData(BigInteger.MinusOne, CultureInfo.CurrentCulture).SetName("-1 (big integer)").Returns(new Fraction(-1));
+
+            yield return new TestCaseData(1m, CultureInfo.CurrentCulture).Returns(Fraction.One);
+            yield return new TestCaseData(0.5m, CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
+
+            yield return new TestCaseData(1d, CultureInfo.CurrentCulture).Returns(Fraction.One);
+            yield return new TestCaseData(0.5d, CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
+
+            yield return new TestCaseData("1", CultureInfo.CurrentCulture).Returns(new Fraction(1));
+            yield return new TestCaseData("123", CultureInfo.CurrentCulture).Returns(new Fraction(123));
+            yield return new TestCaseData("1/2", CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
+            yield return new TestCaseData("-1/2", CultureInfo.CurrentCulture).Returns(new Fraction(-1, 2));
+            yield return new TestCaseData("1/-2", CultureInfo.CurrentCulture).Returns(new Fraction(-1, 2));
+            yield return new TestCaseData("-1/-2", CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
+            yield return new TestCaseData("0,5", new CultureInfo("de-DE")).Returns(new Fraction(1, 2));
+            yield return new TestCaseData("-0,5", new CultureInfo("de-DE")).Returns(new Fraction(-1, 2));
+            yield return new TestCaseData("0.5", new CultureInfo("en-US")).Returns(new Fraction(1, 2));
+            yield return new TestCaseData("-0.5", new CultureInfo("en-US")).Returns(new Fraction(-1, 2));
+            yield return
+                new TestCaseData("-0.125", new CultureInfo("en-US")).Returns(new Fraction(-1, 8));
+
+            yield return new TestCaseData(null, CultureInfo.CurrentCulture).Returns(Fraction.Zero);
         }
+    }
 
-        [Test, TestCaseSource(nameof(TypeTests))]
-        public bool Shall_the_result_of_CanConvertFrom_be_correct(Type destinationType) {
-            return _converter.CanConvertFrom(destinationType);
-        }
+    [Test]
+    [TestCaseSource(nameof(ConvertFromTests))]
+    public Fraction ConvertFrom_ShouldReturnCorrectResult(object value, CultureInfo cultureInfo) {
+        // ReSharper disable once PossibleNullReferenceException
+        var result = (Fraction)_converter.ConvertFrom(null, cultureInfo, value);
+        Console.WriteLine("Type: {0}, Result: {1}", value?.GetType(), result);
 
-        private static IEnumerable<TestCaseData> ConvertFromTests {
-            get {
-                yield return new TestCaseData(Fraction.One, CultureInfo.CurrentCulture).Returns(Fraction.One);
-                yield return new TestCaseData(new Fraction(1, 2), CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
-
-                yield return new TestCaseData(0, CultureInfo.CurrentCulture).SetName("0 (integer)").Returns(Fraction.Zero);
-                yield return new TestCaseData(1, CultureInfo.CurrentCulture).SetName("1 (integer)").Returns(Fraction.One);
-                yield return new TestCaseData(-1, CultureInfo.CurrentCulture).SetName("-1 (integer)").Returns(new Fraction(-1));
-
-                yield return new TestCaseData(0L, CultureInfo.CurrentCulture).SetName("0 (long)").Returns(Fraction.Zero);
-                yield return new TestCaseData(1L, CultureInfo.CurrentCulture).SetName("1 (long)").Returns(Fraction.One);
-                yield return new TestCaseData(-1L, CultureInfo.CurrentCulture).SetName("-1 (long)").Returns(new Fraction(-1));
-                
-                yield return new TestCaseData(BigInteger.Zero, CultureInfo.CurrentCulture).SetName("0 (big integer)").Returns(Fraction.Zero);
-                yield return new TestCaseData(BigInteger.One, CultureInfo.CurrentCulture).SetName("1 (big integer)").Returns(Fraction.One);
-                yield return new TestCaseData(BigInteger.MinusOne, CultureInfo.CurrentCulture).SetName("-1 (big integer)").Returns(new Fraction(-1));
-                
-                yield return new TestCaseData(1m, CultureInfo.CurrentCulture).Returns(Fraction.One);
-                yield return new TestCaseData(0.5m, CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
-
-                yield return new TestCaseData(1d, CultureInfo.CurrentCulture).Returns(Fraction.One);
-                yield return new TestCaseData(0.5d, CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
-
-                yield return new TestCaseData("1", CultureInfo.CurrentCulture).Returns(new Fraction(1));
-                yield return new TestCaseData("123", CultureInfo.CurrentCulture).Returns(new Fraction(123));
-                yield return new TestCaseData("1/2", CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
-                yield return new TestCaseData("-1/2", CultureInfo.CurrentCulture).Returns(new Fraction(-1, 2));
-                yield return new TestCaseData("1/-2", CultureInfo.CurrentCulture).Returns(new Fraction(-1, 2));
-                yield return new TestCaseData("-1/-2", CultureInfo.CurrentCulture).Returns(new Fraction(1, 2));
-                yield return new TestCaseData("0,5", new CultureInfo("de-DE")).Returns(new Fraction(1, 2));
-                yield return new TestCaseData("-0,5", new CultureInfo("de-DE")).Returns(new Fraction(-1, 2));
-                yield return new TestCaseData("0.5", new CultureInfo("en-US")).Returns(new Fraction(1, 2));
-                yield return new TestCaseData("-0.5", new CultureInfo("en-US")).Returns(new Fraction(-1, 2));
-                yield return
-                    new TestCaseData("-0.125", new CultureInfo("en-US")).Returns(new Fraction(-1, 8));
-
-                yield return new TestCaseData(null, CultureInfo.CurrentCulture).Returns(Fraction.Zero);
-            }
-        }
-
-        [Test, TestCaseSource(nameof(ConvertFromTests))]
-        public Fraction Shall_the_result_of_ConvertFrom_be_correct(object value, CultureInfo cultureInfo) {
-            // ReSharper disable once PossibleNullReferenceException
-            var result = (Fraction) _converter.ConvertFrom(null, cultureInfo, value);
-            Console.WriteLine("Type: {0}, Result: {1}", value?.GetType(), result);
-
-            return result;
-        }
+        return result;
     }
 }

--- a/tests/Fractions.Tests/TypeConverters/FractionTypeConverterSpecs/ConvertTo/Method_ConvertTo.cs
+++ b/tests/Fractions.Tests/TypeConverters/FractionTypeConverterSpecs/ConvertTo/Method_ConvertTo.cs
@@ -5,71 +5,73 @@ using Fractions.TypeConverters;
 using NUnit.Framework;
 using Tests.Fractions;
 
-namespace Fractions.Tests.TypeConverters.FractionTypeConverterSpecs.ConvertTo {
-    [TestFixture]
-    public class If_the_user_wants_to_convert_a_Fraction_to_another_type : Spec {
-        private FractionTypeConverter _converter;
+namespace Fractions.Tests.TypeConverters.FractionTypeConverterSpecs.ConvertTo;
 
-        public override void SetUp() {
-            _converter = new FractionTypeConverter();
+[TestFixture]
+public class When_converting_a_Fraction_to_another_type : Spec {
+    private FractionTypeConverter _converter;
+
+    public override void SetUp() {
+        _converter = new FractionTypeConverter();
+    }
+
+    private static IEnumerable TypeTests {
+        get {
+            yield return new TestCaseData(typeof(Fraction)).Returns(true);
+            yield return new TestCaseData(typeof(int)).Returns(true);
+            yield return new TestCaseData(typeof(long)).Returns(true);
+            yield return new TestCaseData(typeof(decimal)).Returns(true);
+            yield return new TestCaseData(typeof(double)).Returns(true);
+            yield return new TestCaseData(typeof(string)).Returns(true);
+            yield return new TestCaseData(typeof(BigInteger)).Returns(true);
+
+            yield return new TestCaseData(typeof(bool)).Returns(false);
+            yield return new TestCaseData(typeof(object)).Returns(false);
         }
+    }
 
-        private static IEnumerable TypeTests {
-            get {
-                yield return new TestCaseData(typeof (Fraction)).Returns(true);
-                yield return new TestCaseData(typeof (int)).Returns(true);
-                yield return new TestCaseData(typeof (long)).Returns(true);
-                yield return new TestCaseData(typeof (decimal)).Returns(true);
-                yield return new TestCaseData(typeof (double)).Returns(true);
-                yield return new TestCaseData(typeof (string)).Returns(true);
-                yield return new TestCaseData(typeof (BigInteger)).Returns(true);
+    [Test]
+    [TestCaseSource(nameof(TypeTests))]
+    public bool CanConvertTo_ShouldReturnCorrectResult(Type destinationType) {
+        return _converter.CanConvertTo(destinationType);
+    }
 
-                yield return new TestCaseData(typeof (bool)).Returns(false);
-                yield return new TestCaseData(typeof (object)).Returns(false);
-            }
+    private static IEnumerable ConvertToTests {
+        get {
+            yield return new TestCaseData(Fraction.One, typeof(Fraction)).Returns(Fraction.One);
+            yield return new TestCaseData(new Fraction(1, 2), typeof(Fraction)).Returns(new Fraction(1, 2));
+
+            yield return new TestCaseData(Fraction.Zero, typeof(int)).Returns(0);
+            yield return new TestCaseData(Fraction.One, typeof(int)).Returns(1);
+            yield return new TestCaseData(new Fraction(-1), typeof(int)).Returns(-1);
+            yield return new TestCaseData(new Fraction(1, 2), typeof(int)).Returns(0);
+            yield return new TestCaseData(new Fraction(-1, 2), typeof(int)).Returns(0);
+
+            yield return new TestCaseData(Fraction.One, typeof(long)).Returns(1L);
+            yield return new TestCaseData(new Fraction(1, 2), typeof(long)).Returns(0L);
+
+            yield return new TestCaseData(Fraction.One, typeof(decimal)).Returns(1m);
+            yield return new TestCaseData(new Fraction(1, 2), typeof(decimal)).Returns(0.5m);
+
+            yield return new TestCaseData(Fraction.One, typeof(double)).Returns(1d);
+            yield return new TestCaseData(new Fraction(1, 2), typeof(double)).Returns(0.5d);
+
+            yield return new TestCaseData(Fraction.One, typeof(string)).Returns("1");
+            yield return new TestCaseData(new Fraction(1, 2), typeof(string)).Returns("1/2");
+
+            yield return new TestCaseData(Fraction.One, typeof(BigInteger)).Returns(BigInteger.One);
+            yield return new TestCaseData(new Fraction(1, 2), typeof(BigInteger)).Returns(BigInteger.Zero);
+            yield return new TestCaseData(new Fraction(-2, 1), typeof(BigInteger)).Returns(new BigInteger(-2));
         }
+    }
 
-        [Test, TestCaseSource(nameof(TypeTests))]
-        public bool Shall_the_result_of_CanConvertTo_be_correct(Type destinationType) {
-            return _converter.CanConvertTo(destinationType);
-        }
+    [Test]
+    [TestCaseSource(nameof(ConvertToTests))]
+    public object ConvertTo_ShouldReturnCorrectResult(Fraction value, Type destinationType) {
+        var result = _converter.ConvertTo(value, destinationType);
+        // ReSharper disable once PossibleNullReferenceException
+        Console.WriteLine("Type: {0}, Value: {1}", result.GetType(), result);
 
-        private static IEnumerable ConvertToTests {
-            get {
-                yield return new TestCaseData(Fraction.One, typeof (Fraction)).Returns(Fraction.One);
-                yield return new TestCaseData(new Fraction(1, 2), typeof (Fraction)).Returns(new Fraction(1, 2));
-
-                yield return new TestCaseData(Fraction.Zero, typeof (int)).Returns(0);
-                yield return new TestCaseData(Fraction.One, typeof (int)).Returns(1);
-                yield return new TestCaseData(new Fraction(-1), typeof (int)).Returns(-1);
-                yield return new TestCaseData(new Fraction(1, 2), typeof (int)).Returns(0);
-                yield return new TestCaseData(new Fraction(-1, 2), typeof (int)).Returns(0);
-
-                yield return new TestCaseData(Fraction.One, typeof (long)).Returns(1L);
-                yield return new TestCaseData(new Fraction(1, 2), typeof (long)).Returns(0L);
-
-                yield return new TestCaseData(Fraction.One, typeof (decimal)).Returns(1m);
-                yield return new TestCaseData(new Fraction(1, 2), typeof (decimal)).Returns(0.5m);
-
-                yield return new TestCaseData(Fraction.One, typeof (double)).Returns(1d);
-                yield return new TestCaseData(new Fraction(1, 2), typeof (double)).Returns(0.5d);
-
-                yield return new TestCaseData(Fraction.One, typeof (string)).Returns("1");
-                yield return new TestCaseData(new Fraction(1, 2), typeof (string)).Returns("1/2");
-
-                yield return new TestCaseData(Fraction.One, typeof (BigInteger)).Returns(BigInteger.One);
-                yield return new TestCaseData(new Fraction(1, 2), typeof (BigInteger)).Returns(BigInteger.Zero);
-                yield return new TestCaseData(new Fraction(-2, 1), typeof (BigInteger)).Returns(new BigInteger(-2));
-            }
-        }
-
-        [Test, TestCaseSource(nameof(ConvertToTests))]
-        public object Shall_the_result_of_ConvertTo_be_correct(Fraction value, Type destinationType) {
-            var result = _converter.ConvertTo(value, destinationType);
-            // ReSharper disable once PossibleNullReferenceException
-            Console.WriteLine("Type: {0}, Value: {1}", result.GetType(), result);
-
-            return result;
-        }
+        return result;
     }
 }


### PR DESCRIPTION
- all phrases translated into english (left comments in german)
- english phrases modified (using "When" and "Should")
- files re-formatted with file-scoped namespaces