### PR TITLE
Added benchmarks for the most common operations

### DIFF
--- a/Fractions.sln
+++ b/Fractions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28922.388
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{B41FB63E-5400-433A-AE72-BA3787D122E6}"
 EndProject
@@ -19,6 +19,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fractions.Tests", "tests\Fractions.Tests\Fractions.Tests.csproj", "{F48B5784-4102-44AB-B07A-18485C21FC07}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fractions.Json.Tests", "tests\Fractions.Json.Tests\Fractions.Json.Tests.csproj", "{1C77D649-95F0-4E45-9D28-568F94574AC2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{4C120F91-A99A-4B82-BCF0-D5A0CB8AF664}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fractions.Benchmarks", "benchmarks\Fractions.Benchmarks\Fractions.Benchmarks.csproj", "{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +64,14 @@ Global
 		{1C77D649-95F0-4E45-9D28-568F94574AC2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1C77D649-95F0-4E45-9D28-568F94574AC2}.Release|x86.ActiveCfg = Release|Any CPU
 		{1C77D649-95F0-4E45-9D28-568F94574AC2}.Release|x86.Build.0 = Release|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Debug|x86.Build.0 = Debug|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Release|x86.ActiveCfg = Release|Any CPU
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,6 +79,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F48B5784-4102-44AB-B07A-18485C21FC07} = {B41FB63E-5400-433A-AE72-BA3787D122E6}
 		{1C77D649-95F0-4E45-9D28-568F94574AC2} = {B41FB63E-5400-433A-AE72-BA3787D122E6}
+		{EDFBDEA0-8117-4EB6-9FE4-F1162C5BBEB1} = {4C120F91-A99A-4B82-BCF0-D5A0CB8AF664}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A6979008-4F24-46CF-8A9B-9E05FCA3AA20}

--- a/benchmarks/Fractions.Benchmarks/BasicMathBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/BasicMathBenchmarks.cs
@@ -1,0 +1,41 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class BasicMathBenchmarks {
+    public static IEnumerable<object[]> Operands() {
+        yield return [new Fraction(0, 1), new Fraction(1, 1)];
+        yield return [new Fraction(-1024, 1), new Fraction(-1, 1024)];
+        yield return [new Fraction(-10 ^ 37, 1), new Fraction(1, 10 ^ 12)];
+        yield return [Fraction.FromDouble(Math.PI), Fraction.FromDouble(Math.PI / 2)];
+        yield return [Fraction.FromDoubleRounded(Math.PI), Fraction.FromDoubleRounded(Math.PI / 2)];
+        yield return [Fraction.FromDouble(Math.PI), Fraction.FromDouble(Math.PI / 3)];
+        yield return [Fraction.FromDoubleRounded(Math.PI), Fraction.FromDoubleRounded(Math.PI / 3)];
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public Fraction Add(Fraction a, Fraction b) {
+        return a + b;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public Fraction Subtract(Fraction a, Fraction b) {
+        return a - b;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public Fraction Multiply(Fraction a, Fraction b) {
+        return a * b;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public Fraction Divide(Fraction a, Fraction b) {
+        return a / b;
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
@@ -1,0 +1,42 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class ComparisonBenchmarks {
+    public static IEnumerable<object[]> Operands() {
+        yield return [new Fraction(0, 1), new Fraction(1, 1)];
+        yield return [new Fraction(-1024, 1), new Fraction(-1, 1024)];
+        yield return [new Fraction(-10 ^ 37, 1), new Fraction(1, 10 ^ 12)];
+        yield return [new Fraction(-10 ^ 37), new Fraction(-10 ^ 37)];
+        yield return [Fraction.FromDouble(Math.PI), Fraction.FromDouble(Math.PI)];
+        yield return [Fraction.FromDoubleRounded(Math.PI), Fraction.FromDoubleRounded(Math.PI)];
+        yield return [Fraction.FromDouble(Math.PI), Fraction.FromDouble(Math.PI / 3)];
+        yield return [Fraction.FromDoubleRounded(Math.PI), Fraction.FromDoubleRounded(Math.PI / 3)];
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public bool Equals(Fraction a, Fraction b) {
+        return a.Equals(b);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public bool IsEquivalentTo(Fraction a, Fraction b) {
+        return a.IsEquivalentTo(b);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public int GetHashCode(Fraction a, Fraction b) {
+        return HashCode.Combine(a, b);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public int CompareTo(Fraction a, Fraction b) {
+        return a.CompareTo(b);
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/ConstructorBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ConstructorBenchmarks.cs
@@ -1,0 +1,46 @@
+﻿using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+public class ConstructorBenchmarks {
+    public static IEnumerable<int> IntegerValues => [0, 42, int.MinValue, int.MaxValue];
+    public static IEnumerable<decimal> DecimalValues => [0m, 42m, 123.45m, int.MinValue, decimal.MinValue, (decimal)Math.PI];
+    public static IEnumerable<double> DoubleValues => [0.0, 42, 123.45, (double)decimal.MinValue, double.MaxValue, Math.PI];
+
+    public IEnumerable<object[]> BigIntegerValues() 
+    {
+        yield return [new BigInteger(0), new BigInteger(1)];
+        yield return [new BigInteger(42), new BigInteger(1)];
+        yield return [new BigInteger(int.MinValue), new BigInteger(1)];
+        yield return [new BigInteger(int.MaxValue), new BigInteger(int.MaxValue)];
+        yield return [new BigInteger(decimal.MinValue), new BigInteger(int.MaxValue)]; // TODO check if this is reduced
+        yield return [new BigInteger(int.MaxValue), new BigInteger(double.MaxValue)];
+        yield return [new BigInteger(245850922), new BigInteger(78256779)]; // ~ PI
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(IntegerValues))]
+    public Fraction Construct_With_Int32(int value) {
+        return new Fraction(value);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(DecimalValues))]
+    public Fraction Construct_With_Decimal(decimal value) {
+        return new Fraction(value);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(DoubleValues))]
+    public Fraction Construct_With_Double(double value) {
+        return new Fraction(value);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(BigIntegerValues))]
+    public Fraction Construct_With_BigIntegers(BigInteger numerator, BigInteger denominator) {
+        return new Fraction(numerator, denominator);
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/ConvertToNumberBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ConvertToNumberBenchmarks.cs
@@ -1,0 +1,28 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+public class ConvertToNumberBenchmarks {
+
+    public static IEnumerable<Fraction> FractionsToConvert => [
+        Fraction.Zero, 
+        Fraction.One, 
+        10,
+        new Fraction(1, 10),
+        new Fraction(1, 3),
+        new Fraction(decimal.MaxValue)
+    ];
+    
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(FractionsToConvert))]
+    public double ConvertToDouble(Fraction fraction) {
+        return fraction.ToDouble();
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(FractionsToConvert))]
+    public decimal ConvertToDecimal(Fraction fraction) {
+        return fraction.ToDecimal();
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
+++ b/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
+++ b/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
+++ b/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fractions\Fractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Fractions.Benchmarks/FromDoubleBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/FromDoubleBenchmarks.cs
@@ -1,0 +1,45 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+public class FromDoubleBenchmarks {
+    private static readonly Fraction Zero = Fraction.Zero; // helps with the static initializers
+    
+    public static IEnumerable<double> DoubleValues => [
+        0, double.NaN, double.PositiveInfinity, double.NegativeInfinity,
+        42,
+        1.345,
+        1.0/3,
+        -37*10e-8,
+        1024*10e8,
+        2110.11170524,
+        0.022046226218487758,
+        5.9722E+24,
+        -1.0/37,
+        (0.001 / 1e3) * 100000,
+        (double)decimal.MinValue,
+        double.MaxValue,
+        Math.PI
+    ];
+
+    [Benchmark()]
+    [ArgumentsSource(nameof(DoubleValues))]
+    public Fraction Construct_FromDouble(double value) {
+        try {
+            return Fraction.FromDouble(value);
+        } catch (InvalidNumberException) {
+            return Zero;
+        }
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(DoubleValues))]
+    public Fraction Construct_FromDoubleRounded(double value) {
+        try {
+            return Fraction.FromDoubleRounded(value);
+        } catch (InvalidNumberException) {
+            return Zero;
+        }
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/FromStringBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/FromStringBenchmarks.cs
@@ -1,0 +1,24 @@
+﻿using System.Globalization;
+using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class FromStringBenchmarks {
+
+    public static IEnumerable<string> ValidStrings => ["0", "1", "-1", "10242048", "1/5", "-1/5", "3.5", "-3.5", "1.2345678901234567890"];
+    public static IEnumerable<string> InvalidStrings => ["", "invalid", "-10242048/", "1.2345678901234567890f"];
+    
+    [Benchmark]
+    [ArgumentsSource(nameof(ValidStrings))]
+    public bool TryParseValidString(string validString) {
+        return Fraction.TryParse(validString, NumberStyles.Number, CultureInfo.InvariantCulture, false, out _);
+    }
+    
+    [Benchmark]
+    [ArgumentsSource(nameof(InvalidStrings))]
+    public bool TryParseInvalidString(string invalidString) {
+        return Fraction.TryParse(invalidString, NumberStyles.Number, CultureInfo.InvariantCulture, false, out _);
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/PowerMathBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/PowerMathBenchmarks.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+// [DryJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class PowerMathBenchmarks {
+    public static IEnumerable<int> Powers => [0, 1, 2, -2, 50, 100];
+
+    public static IEnumerable<Fraction> FractionsToRaise => [2, 3, new Fraction(2, 3), 1024];
+
+    [ParamsSource(nameof(FractionsToRaise))]
+    public Fraction FractionToRaise { get; set; }
+
+
+    [Benchmark]
+    [BenchmarkCategory("Pow")]
+    [ArgumentsSource(nameof(Powers))]
+    public Fraction Power(int exponent) {
+        return Fraction.Pow(FractionToRaise, exponent);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Sqrt")]
+    public Fraction Sqrt() {
+        return FractionToRaise.Sqrt();
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/Program.cs
+++ b/benchmarks/Fractions.Benchmarks/Program.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+internal class Program
+{
+    static void Main(string[] args)
+    {
+        var switcher = new BenchmarkSwitcher(Assembly.GetExecutingAssembly());
+        Console.Out.WriteLine("Starting benchmarks with args = {0}", string.Join(" ", args));
+        if (Debugger.IsAttached)
+        {
+            Console.Out.WriteLine("Using an attached debugger: setting configuration to DebugInProcessConfig");
+            switcher.Run(args, new DebugInProcessConfig());
+        }
+        else
+        {
+            switcher.Run(args);
+        }
+    }
+}

--- a/benchmarks/Fractions.Benchmarks/ToStringBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ToStringBenchmarks.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class ToStringBenchmarks {
+
+    [Params(null, "G", "n", "d", "z", "r", "m")]
+    public string? StringFormat { get; set; }
+    
+    public static IEnumerable<Fraction> TestValues => [
+        42,
+        new Fraction(-2.5m),
+        new Fraction(1.345m),        
+        new Fraction(8, 3),
+        new Fraction(Math.PI)
+    ];
+    
+    [Benchmark]
+    [ArgumentsSource(nameof(TestValues))]
+    public string ToString_Fraction(Fraction fraction) {
+        return fraction.ToString(StringFormat);
+    }
+}


### PR DESCRIPTION
I'm attaching the results from my local runs (from over a week ago)- note however that those were run in a "noisy environment" (and some probably even contain additional tests that were later removed).

You should ideally run them yourself (or perhaps I'll post an updated version of the results at a later point). You could then add the md files to the gh-pages (renaming the *report.md to README.me would also make it show up when navigating the to the [root folder](https://github.com/lipchev/UnitsNet-Benchmarks/tree/gh-pages/benchmarks/netcoreapp50/Micro/Comparison/results)).

I've already tested a couple of minor tweaks that yielded some performance gains, but I'll post those in separate PRs after this is merged.

[results.zip](https://github.com/danm-de/Fractions/files/14937624/results.zip)
