### PR TITLE
Make the operator from decimal implicit

### DIFF
--- a/src/Fractions/Fraction.Operators.cs
+++ b/src/Fractions/Fraction.Operators.cs
@@ -41,7 +41,7 @@ public readonly partial struct Fraction {
 
     public static explicit operator Fraction(double value) => new(value);
 
-    public static explicit operator Fraction(decimal value) => new(value);
+    public static implicit operator Fraction(decimal value) => new(value);
 
     public static explicit operator Fraction(string value) => FromString(value);
 


### PR DESCRIPTION
Was there a reason for this not being an implicit operator?

PS.
Should also update the gh-pages branch.