### PR TITLE
Add the Fraction.Round functions (prototype from decimal.Round)

### DIFF
--- a/src/Fractions/Fraction.Math.cs
+++ b/src/Fractions/Fraction.Math.cs
@@ -192,4 +192,95 @@ public readonly partial struct Fraction {
                 numerator: fraction.Denominator,
                 denominator: fraction.Numerator,
                 state: fraction.State);
+
+    /// <summary>
+    ///     Rounds the given Fraction to the specified precision using the specified rounding strategy.
+    /// </summary>
+    /// <param name="fraction">The Fraction to be rounded.</param>
+    /// <param name="decimals">The number of significant decimal places (precision) in the return value.</param>
+    /// <param name="mode">One of the enumeration values that specifies which rounding strategy to use.</param>
+    /// <returns>The number that <paramref name="fraction" /> is rounded to using the <paramref name="mode" /> rounding strategy and with a precision of <paramref name="decimals" />. If the precision of <paramref name="fraction" /> is less than <paramref name="decimals" />, <paramref name="fraction" /> is returned unchanged.</returns>
+    public static Fraction Round(Fraction fraction, int decimals, MidpointRounding mode = MidpointRounding.ToEven) {
+        if (decimals < 0) {
+            throw new ArgumentOutOfRangeException(nameof(decimals));
+        }
+        
+        if (fraction.IsZero || fraction.Denominator.IsOne) {
+            return fraction;
+        }
+
+        var factor = BigInteger.Pow(TEN, decimals);
+        var roundedNumerator = Round(fraction.Numerator * factor, fraction.Denominator, mode);
+        return new Fraction(roundedNumerator, factor);
+    }
+    
+    /// <summary>
+    ///     Rounds the given Fraction to the specified precision using the specified rounding strategy.
+    /// </summary>
+    /// <param name="fraction">The Fraction to be rounded.</param>
+    /// <param name="mode">One of the enumeration values that specifies which rounding strategy to use.</param>
+    /// <returns>The number that <paramref name="fraction" /> is rounded to using the <paramref name="mode" /> rounding strategy.</returns>
+    public static BigInteger Round(Fraction fraction, MidpointRounding mode = MidpointRounding.ToEven) {
+        return Round(fraction.Numerator, fraction.Denominator, mode);
+    }
+
+    /// <summary>
+    ///     Rounds the given Fraction to the specified precision using the specified rounding strategy.
+    /// </summary>
+    /// <param name="numerator">The numerator of the fraction to be rounded.</param>
+    /// <param name="denominator">The denominator of the fraction to be rounded.</param>
+    /// <param name="mode">One of the enumeration values that specifies which rounding strategy to use.</param>
+    /// <returns>The number rounded to using the <paramref name="mode" /> rounding strategy.</returns>
+    private static BigInteger Round(BigInteger numerator, BigInteger denominator, MidpointRounding mode = MidpointRounding.ToEven) {
+        if (numerator.IsZero || denominator.IsOne) {
+            return numerator;
+        }
+        
+        return mode switch {
+            MidpointRounding.AwayFromZero => roundAwayFromZero(numerator, denominator),
+            MidpointRounding.ToEven => roundToEven(numerator, denominator),
+#if NET
+            MidpointRounding.ToZero => BigInteger.Divide(numerator, denominator),
+            MidpointRounding.ToPositiveInfinity => roundToPositiveInfinity(numerator, denominator),
+            MidpointRounding.ToNegativeInfinity => roundToNegativeInfinity(numerator, denominator),
+#endif
+            _ => throw new ArgumentOutOfRangeException(nameof(mode))
+        };
+
+        static BigInteger roundAwayFromZero(BigInteger numerator, BigInteger denominator) {
+            return numerator.Sign == denominator.Sign
+                ? BigInteger.Divide(numerator + denominator / 2, denominator)
+                : BigInteger.Divide(numerator - denominator / 2, denominator);
+        }
+
+        static BigInteger roundToEven(BigInteger numerator, BigInteger denominator) {
+            var quotient = BigInteger.DivRem(numerator, denominator, out var remainder);
+            var half = denominator / 2;
+            if (numerator.Sign == denominator.Sign) {
+                // For positive values or when both values are negative
+                if (remainder > half || (remainder == half && !quotient.IsEven)) {
+                    return quotient + 1;
+                }
+            } else {
+                // For negative values
+                remainder = -remainder;
+                if (remainder > half || (remainder == half && !quotient.IsEven)) {
+                    return quotient - 1;
+                }
+            }
+
+            return quotient;
+        }
+#if NET
+        static BigInteger roundToPositiveInfinity(BigInteger numerator, BigInteger denominator) {
+            var quotient = BigInteger.DivRem(numerator, denominator, out var remainder);
+            return remainder.Sign == 1 ? quotient + 1 : quotient;
+        }
+
+        static BigInteger roundToNegativeInfinity(BigInteger numerator, BigInteger denominator) {
+            var quotient = BigInteger.DivRem(numerator, denominator, out var remainder);
+            return remainder.Sign == -1 ? quotient - 1 : quotient;
+        }
+#endif
+    }
 }

--- a/src/Fractions/Fraction.cs
+++ b/src/Fractions/Fraction.cs
@@ -15,6 +15,7 @@ namespace Fractions;
 public readonly partial struct Fraction : IEquatable<Fraction>, IComparable, IComparable<Fraction>, IFormattable {
     private static readonly BigInteger MIN_DECIMAL = new(decimal.MinValue);
     private static readonly BigInteger MAX_DECIMAL = new(decimal.MaxValue);
+    private static readonly BigInteger TEN = new(10);
     private static readonly Fraction _zero = new(BigInteger.Zero, BigInteger.Zero, FractionState.IsNormalized);
     private static readonly Fraction _one = new(BigInteger.One, BigInteger.One, FractionState.IsNormalized);
     private static readonly Fraction _minusOne = new(BigInteger.MinusOne, BigInteger.One, FractionState.IsNormalized);

--- a/src/Fractions/Fractions.csproj
+++ b/src/Fractions/Fractions.csproj
@@ -24,6 +24,7 @@
     <PackageIcon>Fraction.png</PackageIcon>
     <PackageLicenseFile>license.txt</PackageLicenseFile>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Fractions/Fractions.csproj
+++ b/src/Fractions/Fractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <Product>Fraction data type</Product>
     <Authors>Daniel Mueller</Authors>
     <Copyright>Copyright 2013-2024 Daniel Mueller</Copyright>

--- a/tests/Fractions.Tests/FractionSpecs/Round/Method_Round.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Round/Method_Round.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Numerics;
+using FluentAssertions;
+using NUnit.Framework;
+using Tests.Fractions;
+
+namespace Fractions.Tests.FractionSpecs.Round;
+
+[TestFixture]
+public class When_rounding_a_decimal_fraction : Spec {
+    
+    private static readonly decimal[] DecimalValues = [
+        0, 1, -1, 10, -10, 
+        0.5m, -0.5m, 0.55m, -0.55m, 1.5m, -1.5m, 1.55m, -1.55m, 
+        0.1m, -0.1m, 0.15m, -0.15m, 1.2m, -1.2m, 1.25m, -1.25m, 
+        1.5545665434654m, -1.5545665434654m,
+        15.545665434654m, -15.545665434654m,
+        155.45665434654m, -155.45665434654m,
+        1554.5665434654m, -1554.5665434654m,
+        15545.665434654m, -15545.665434654m,
+        155456.65434654m, -155456.65434654m
+    ];
+    
+    private static readonly int[] DecimalPlaces = Enumerable.Range(0, 6).ToArray();
+
+    private static readonly MidpointRounding[] RoundingModes = [
+        MidpointRounding.ToEven,
+        MidpointRounding.AwayFromZero,
+#if NET
+        MidpointRounding.ToZero,
+        MidpointRounding.ToNegativeInfinity,
+        MidpointRounding.ToPositiveInfinity
+#endif
+    ];
+
+    private static IEnumerable RoundToBigIntegerTestCases =>
+        from decimalValue in DecimalValues
+        from midpointRounding in RoundingModes
+        select new TestCaseData(new Fraction(decimalValue), midpointRounding)
+            .Returns((BigInteger)decimal.Round(decimalValue, midpointRounding));
+
+
+    [Test]
+    [TestCaseSource(nameof(RoundToBigIntegerTestCases))]
+    public BigInteger The_integral_result_should_be_correct_for_all_decimal_values(Fraction fraction, MidpointRounding roundingMode) {
+        return Fraction.Round(fraction, roundingMode);
+    }
+
+    private static IEnumerable RoundToFractionTestCases =>
+        from decimalValue in DecimalValues
+        from decimalPlaces in DecimalPlaces
+        from midpointRounding in RoundingModes
+        select new TestCaseData(new Fraction(decimalValue), decimalPlaces, midpointRounding)
+            .Returns(new Fraction(decimal.Round(decimalValue, decimalPlaces, midpointRounding)));
+
+    [Test]
+    [TestCaseSource(nameof(RoundToFractionTestCases))]
+    public Fraction The_fractional_result_should_be_correct_for_all_decimal_values(Fraction fraction, int decimalPlaces, MidpointRounding roundingMode) {
+        return Fraction.Round(fraction, decimalPlaces, roundingMode);
+    }
+    
+    [Test]
+    public void The_fractional_result_should_be_correct_for_very_large_values() {
+        var a = new BigInteger(123456789987654321);
+        var b = new BigInteger(123456789987654321) * BigInteger.Pow(10, 18);
+        var largeValue = a + b; // should represent the value 123456789987654321123456789987654321
+        var middle = new Fraction(largeValue, BigInteger.Pow(10, 18)); // place the decimal point in the middle
+        var valueToTest = middle / BigInteger.Pow(10, 17);
+
+        var roundedValue = Fraction.Round(valueToTest, 36);
+
+        roundedValue.Should().Be(valueToTest);
+    }
+}

--- a/tests/Fractions.Tests/Fractions.Tests.csproj
+++ b/tests/Fractions.Tests/Fractions.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I've added to Round(..) functions to the Fraction type itself (same as the decimal), but if you prefer we could move it to the MathExt class.. 

Note that the `MidpointRounding` enum [was extended](https://learn.microsoft.com/en-us/dotnet/api/system.midpointrounding?view=netcore-3.0) in .NET Core 3.0.
I have added the corresponding `#if NET` check and throwing an exception if the mode is not available, but this only makes sense if we actually bump the project version (otherwise the associated tests would fail). 

I have therefore changed the netstandard2.1 target to net7.0 (the app-veyor image needs to be update in order to support net8.0).