### PR TITLE
Extended the Pow/Sqrt functions with their fractional-exponent overloads

### DIFF
--- a/src/Fractions/Extensions/FractionExt.cs
+++ b/src/Fractions/Extensions/FractionExt.cs
@@ -44,4 +44,49 @@ public static class FractionExt {
 
         return newGuess;
     }
+
+    /// <summary>
+    ///     Raises a fraction to the power of another fraction.
+    /// </summary>
+    /// <param name="x">The base fraction.</param>
+    /// <param name="power">The exponent fraction.</param>
+    /// <param name="minAccuracy">The minimum accuracy for the result.</param>
+    /// <returns>The result of raising the base fraction to the power of the exponent fraction.</returns>
+    public static Fraction Pow(this Fraction x, Fraction power, Fraction minAccuracy)
+    {
+        var numeratorRaised = Fraction.Pow(x, (int)power.Numerator);
+        return numeratorRaised.Root((int)power.Denominator, minAccuracy);
+    }
+
+    /// <summary>
+    ///     Calculates the nth root of the given fraction with a specified minimum accuracy.
+    /// </summary>
+    /// <param name="number">The fraction for which to calculate the nth root.</param>
+    /// <param name="n">The root to calculate. For example, if n is 2, the method calculates the square root.</param>
+    /// <param name="minAccuracy">
+    ///     The minimum accuracy of the result. The method continues to calculate the root until the
+    ///     difference between two successive approximations is less than this value.
+    /// </param>
+    /// <returns>The nth root of the fraction, calculated to the specified minimum accuracy.</returns>
+    public static Fraction Root(this Fraction number, int n, Fraction minAccuracy) {
+        //Babylonian Method of computing the nth-square root
+
+        if (number < Fraction.Zero) {
+            throw new OverflowException("Cannot calculate square root from a negative number");
+        }
+
+        if (minAccuracy <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(minAccuracy), minAccuracy, $"Accuracy of {minAccuracy} is not allowed! Have to be above 0.");
+        }
+
+        var initialGuess = Math.Pow(number.ToDouble(), 1.0 / n);
+        var x = initialGuess == 0.0 ? number : Fraction.FromDoubleRounded(initialGuess);
+        Fraction xPrev;
+        do {
+            xPrev = x;
+            x = ((n - 1) * x + number / Fraction.Pow(x, n - 1)) / n;
+        } while ((x - xPrev).Abs() > minAccuracy);
+
+        return x;
+    }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Pow/Method_Pow.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Pow/Method_Pow.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.Numerics;
 using NUnit.Framework;
 using Tests.Fractions;
 
@@ -31,5 +35,50 @@ public class When_exponentiation_is_applied_to_a_fraction : Spec {
     // German: Das Ergebnis sollte korrekt sein
     public Fraction The_result_should_be_correct(Fraction fraction, int power) {
         return Fraction.Pow(fraction, power);
+    }
+}
+
+[TestFixture]
+public class When_the_Pow_function_is_called_with_a_fractional_exponent : Spec {
+    
+    [Test]
+    public void The_square_root_of_1_should_be_1() {
+        Fraction.One.Root(2, new Fraction(BigInteger.One, 100))
+            .Should().Be(1);
+    }
+
+    [Test]
+    public void The_square_root_of_minus_one_should_fail() {
+        Action act = () => Fraction.MinusOne.Root(2, new Fraction(BigInteger.One, 100));
+        act.Should().Throw<OverflowException>()
+            .WithMessage("Cannot calculate square root from a negative number");
+    }
+
+    [Test]
+    public void The_square_root_of_minus_one_should_fail_with_negative_accuracy() {
+        Action act = () => Fraction.One.Root(2, new Fraction(BigInteger.MinusOne, 100));
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(0.001, 2);
+            yield return new TestCaseData(5, 0.5);
+            yield return new TestCaseData(4.54854751, 2.25);
+            yield return new TestCaseData(9999999855487, -2.5);
+            yield return new TestCaseData(99999998554865557, -3);
+            yield return new TestCaseData(Math.PI, 3);
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void The_result_should_be_equal_to_Math_Sqrt(double value, double exponent) {
+        var expected = Math.Pow(value, exponent);
+        
+        var maxDifference = new Fraction(BigInteger.One, BigInteger.Pow(new BigInteger(10), 10));
+        var actual = Fraction.FromDouble(value).Pow(Fraction.FromDoubleRounded(exponent), maxDifference);
+        
+        actual.ToDouble().Should().BeApproximately(expected, maxDifference.ToDouble());
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Sqrt/Method_Root.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Sqrt/Method_Root.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using FluentAssertions;
+using NUnit.Framework;
+using Tests.Fractions;
+
+namespace Fractions.Tests.FractionSpecs.Sqrt;
+
+[TestFixture]
+public class When_the_Root_function_is_called : Spec {
+    
+    [Test]
+    public void The_square_root_of_1_should_be_1() {
+        Fraction.One.Root(2, new Fraction(BigInteger.One, 100))
+            .Should().Be(1);
+    }
+
+    [Test]
+    public void The_square_root_of_minus_one_should_fail() {
+        Action act = () => Fraction.MinusOne.Root(2, new Fraction(BigInteger.One, 100));
+        act.Should().Throw<OverflowException>()
+            .WithMessage("Cannot calculate square root from a negative number");
+    }
+
+    [Test]
+    public void The_square_root_of_minus_one_should_fail_with_negative_accuracy() {
+        Action act = () => Fraction.One.Root(2, new Fraction(BigInteger.MinusOne, 100));
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(0.001, 2);
+            yield return new TestCaseData(5, 3);
+            yield return new TestCaseData(4.54854751, 2);
+            yield return new TestCaseData(9999999855487, 4);
+            yield return new TestCaseData(99999998554865557, 2);
+            yield return new TestCaseData(Math.PI, 3);
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void The_result_should_be_equal_to_Math_Sqrt(double value, int rootNumber) {
+        var expected = Math.Pow(value, 1.0 / rootNumber);
+        
+        var maxDifference = new Fraction(BigInteger.One, BigInteger.Pow(new BigInteger(10), 10));
+        var actual = Fraction.FromDouble(value).Root(rootNumber, maxDifference);
+        
+        actual.ToDouble().Should().BeApproximately(expected, maxDifference.ToDouble());
+    }
+}


### PR DESCRIPTION
Similar to `Math.Pow(double x, double y)` but with the added accuracy parameter..

I'm really not sure about this one...when used "unwisely" - there are many ways this could lead to an overflow / never-ending loop..

Personally, I don't think I will ever need this, and was in fact about to delete it- but if you want it (or if it ever comes up again later), well here it is.. 