### PR TITLE
Support for parsing long/very precise numbers

### DIFF
--- a/src/Fractions/Fraction.cs
+++ b/src/Fractions/Fraction.cs
@@ -15,6 +15,7 @@ namespace Fractions;
 public readonly partial struct Fraction : IEquatable<Fraction>, IComparable, IComparable<Fraction>, IFormattable {
     private static readonly BigInteger MIN_DECIMAL = new(decimal.MinValue);
     private static readonly BigInteger MAX_DECIMAL = new(decimal.MaxValue);
+    private static readonly BigInteger TEN = new (10);
     private static readonly Fraction _zero = new(BigInteger.Zero, BigInteger.Zero, FractionState.IsNormalized);
     private static readonly Fraction _one = new(BigInteger.One, BigInteger.One, FractionState.IsNormalized);
     private static readonly Fraction _minusOne = new(BigInteger.MinusOne, BigInteger.One, FractionState.IsNormalized);

--- a/src/Fractions/Fractions.csproj
+++ b/src/Fractions/Fractions.csproj
@@ -24,6 +24,7 @@
     <PackageIcon>Fraction.png</PackageIcon>
     <PackageLicenseFile>license.txt</PackageLicenseFile>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
@@ -183,5 +184,150 @@ public class When_creating_a_fraction_from_the_string_minus_64_over_40_by_explic
     // German: Das Ergebnis sollte korrekt sein
     public void The_result_should_be_correct() {
         _result.Should().Be(new Fraction(-64, 40));
+    }
+}
+    
+[TestFixture]
+public class When_creating_a_fraction_from_a_very_long_decimal_string : Spec {
+    private string _valueToParse;
+    private Fraction _expectedFraction;
+
+    private Fraction _result;
+    
+    public override void Arrange() {
+        _valueToParse = "123456789987654321.123456789987654321";
+        BigInteger a = new BigInteger(123456789987654321);
+        BigInteger b = new BigInteger(123456789987654321) * BigInteger.Pow(10, 18);
+        var largeValue = a + b; // should represent the value 123456789987654321123456789987654321
+        _expectedFraction = new Fraction(largeValue, BigInteger.Pow(10, 18)); // place the decimal point in the middle
+    }
+
+    public override void Act() {
+        _result = Fraction.FromString(_valueToParse);
+    }
+
+    [Test]
+    public void The_number_is_parsed_without_any_loss_of_precision() {
+        _result.Should().Be(_expectedFraction);
+    }
+}
+  
+[TestFixture]
+public class Parsing_a_string_with_scientific_notation_representing_a_large_positive_number : Spec {
+    private Fraction _expectedFraction;
+    
+    public override void Arrange() {
+        _expectedFraction = new Fraction(new BigInteger(123456789987654321) * BigInteger.Pow(10,  24));
+    }
+    
+    [Test]
+    public void Should_not_work_by_default([Values("1.23456789987654321E+41", "1.23456789987654321e+41")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse))
+            .Should()
+            .Throw<FormatException>();
+    }
+
+    [Test]
+    public void Should_work_without_loss_of_precision_with_NumberStyle_Any(
+        [Values("1.23456789987654321E+41", "1.23456789987654321e+41")]
+        string valueToParse) {
+        Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")).Should().Be(_expectedFraction);
+    }
+
+    [Test]
+    public void Should_not_work_for_decimal_exponents([Values("1.23456789987654321E+41.5", "1.23456789987654321e+41.5")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")))
+            .Should()
+            .Throw<FormatException>();
+    }
+}
+  
+[TestFixture]
+public class Parsing_a_string_with_scientific_notation_representing_a_large_negative_number : Spec {
+    private Fraction _expectedFraction;
+    
+    public override void Arrange() {
+        _expectedFraction = new Fraction(new BigInteger(-123456789987654321) * BigInteger.Pow(10,  24));
+    }
+    
+    [Test]
+    public void Should_not_work_by_default([Values("-1.23456789987654321E+41", "-1.23456789987654321e+41")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse))
+            .Should()
+            .Throw<FormatException>();
+    }
+
+    [Test]
+    public void Should_work_without_loss_of_precision_with_NumberStyle_Any(
+        [Values("-1.23456789987654321E+41", "-1.23456789987654321e+41")]
+        string valueToParse) {
+        Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")).Should().Be(_expectedFraction);
+    }
+
+    [Test]
+    public void Should_not_work_for_decimal_exponents([Values("-1.23456789987654321E+41.5", "-1.23456789987654321e+41.5")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")))
+            .Should()
+            .Throw<FormatException>();
+    }
+}
+
+[TestFixture]
+public class Parsing_a_string_with_scientific_notation_representing_a_small_positive_number : Spec {
+    private Fraction _expectedFraction;
+    
+    public override void Arrange() {
+        _expectedFraction = new Fraction(new BigInteger(123456789987654321), BigInteger.Pow(10, 17 + 24));
+    }
+    
+    [Test]
+    public void Should_not_work_by_default([Values("1.23456789987654321E-24", "1.23456789987654321e-24")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse))
+            .Should()
+            .Throw<FormatException>();
+    }
+
+    [Test]
+    public void Should_work_without_loss_of_precision_with_NumberStyle_Any(
+        [Values("1.23456789987654321E-24", "1.23456789987654321e-24")]
+        string valueToParse) {
+        Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")).Should().Be(_expectedFraction);
+    }
+
+    [Test]
+    public void Should_not_work_for_decimal_exponents([Values("1.23456789987654321E-24.5", "1.23456789987654321e-24.5")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")))
+            .Should()
+            .Throw<FormatException>();
+    }
+}
+
+[TestFixture]
+public class Parsing_a_string_with_scientific_notation_representing_a_small_negative_number : Spec {
+    private Fraction _expectedFraction;
+    
+    public override void Arrange() {
+        _expectedFraction = new Fraction(new BigInteger(-123456789987654321), BigInteger.Pow(10, 17 + 24));
+    }
+    
+    [Test]
+    public void Should_not_work_by_default([Values("-1.23456789987654321E-24", "-1.23456789987654321e-24")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse))
+            .Should()
+            .Throw<FormatException>();
+    }
+
+    [Test]
+    public void Should_work_without_loss_of_precision_with_NumberStyle_Any(
+        [Values("-1.23456789987654321E-24", "-1.23456789987654321e-24")]
+        string valueToParse) {
+        Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")).Should().Be(_expectedFraction);
+    }
+
+    [Test]
+    public void Should_not_work_for_decimal_exponents([Values("-1.23456789987654321E-24.5", "-1.23456789987654321e-24.5")] string valueToParse) {
+        Invoking(() => Fraction.FromString(valueToParse, NumberStyles.Any, new CultureInfo("en-US")))
+            .Should()
+            .Throw<FormatException>();
     }
 }


### PR DESCRIPTION
- added support for parsing of numbers beyond the standard decimal range: 

> 123456789987654321.123456789987654321

- adding support for parsing strings with scientific notation (when the `NumberStyle.AllowExponent` is set):

> 1.23456789987654321E-24