### PR TITLE
FromDouble with significant digits

### DIFF
--- a/benchmarks/Fractions.Benchmarks/FromDoubleBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/FromDoubleBenchmarks.cs
@@ -42,4 +42,24 @@ public class FromDoubleBenchmarks {
             return Zero;
         }
     }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(DoubleValues))]
+    public Fraction Construct_FromDoubleRoundedToFifteenDigits(double value) {
+        try {
+            return Fraction.FromDoubleRounded(value, 15);
+        } catch (InvalidNumberException) {
+            return Zero;
+        }
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(DoubleValues))]
+    public Fraction Construct_FromDoubleRoundedToEighteenDigits(double value) {
+        try {
+            return Fraction.FromDoubleRounded(value, 18);
+        } catch (InvalidNumberException) {
+            return Zero;
+        }
+    }
 }

--- a/src/Fractions/Fraction.ConvertFrom.cs
+++ b/src/Fractions/Fraction.ConvertFrom.cs
@@ -377,10 +377,6 @@ public readonly partial struct Fraction {
     /// <returns>A fraction</returns>
     /// <exception cref="InvalidNumberException">If <paramref name="value"/> is NaN (not a number) or infinite.</exception>
     public static Fraction FromDouble(double value) {
-        if (double.IsNaN(value) || double.IsInfinity(value)) {
-            throw new InvalidNumberException();
-        }
-
         // No rounding here! It will convert the actual number that is stored as double! 
         // See http://www.mpdvc.de/artikel/FloatingPoint.htm
         const ulong SIGN_BIT = 0x8000000000000000;
@@ -388,7 +384,6 @@ public readonly partial struct Fraction {
         const ulong MANTISSA = 0x000FFFFFFFFFFFFF;
         const ulong MANTISSA_DIVISOR = 0x0010000000000000;
         const ulong K = 1023;
-        var one = BigInteger.One;
 
         // value = (-1 * sign)   *   (1 + 2^(-1) + 2^(-2) .. + 2^(-52))   *   2^(exponent-K)
         var valueBits = unchecked((ulong)BitConverter.DoubleToInt64Bits(value));
@@ -402,21 +397,32 @@ public readonly partial struct Fraction {
         var mantissaBits = valueBits & MANTISSA;
 
         // (exponent-K)
-        var exponent = (int)(((valueBits & EXPONENT_BITS) >> 52) - K);
+        var exponentBits = (valueBits & EXPONENT_BITS);
+
+        if (exponentBits == EXPONENT_BITS) {
+            // NaN or Infinity
+            if (mantissaBits != 0) {
+                throw new InvalidNumberException("NaN values are not supported.");
+            }
+
+            // Infinity
+            throw isNegative
+                ? new InvalidNumberException("Negative infinity (-Infinity) is not supported.")
+                : new InvalidNumberException("Positive infinity (+Infinity) is not supported.");
+        }
+        
+        var exponent = (int)((exponentBits >> 52) - K);
 
         // (1 + 2^(-1) + 2^(-2) .. + 2^(-52))
         var mantissa = new Fraction(mantissaBits + MANTISSA_DIVISOR, MANTISSA_DIVISOR);
-
+        
+        var factorSign = isNegative ? BigInteger.MinusOne : BigInteger.One;
         // 2^exponent
         var factor = exponent < 0
-            ? new Fraction(one, one << Math.Abs(exponent))
-            : new Fraction(one << exponent);
+            ? new Fraction(factorSign, BigInteger.One << -exponent)
+            : new Fraction(factorSign << exponent);
 
-        var result = mantissa * factor;
-
-        return isNegative
-            ? result.Invert()
-            : result;
+        return mantissa * factor;
     }
 
     /// <summary>
@@ -469,6 +475,73 @@ public readonly partial struct Fraction {
             new BigInteger(denominator),
             true);
     }
+    
+
+    /// <summary>
+    ///     Converts a floating point value to a Fraction. The value is rounded if possible.
+    /// </summary>
+    /// <param name="value">The floating point value to convert.</param>
+    /// <param name="nbSignificantDigits"></param>
+    /// <returns>A Fraction representing the rounded floating point value.</returns>
+    /// <remarks>
+    ///     The double data type stores its values as 64-bit floating point numbers in accordance with the IEC 60559:1989 (IEEE
+    ///     754) standard for binary floating-point arithmetic.
+    ///     However, the double data type cannot precisely store some binary fractions. For instance, 1/10, which is accurately
+    ///     represented by .1 as a decimal fraction, is represented by .0001100110011... as a binary fraction, with the pattern
+    ///     0011 repeating indefinitely.
+    ///     In such cases, the floating-point value provides an approximate representation of the number.
+    ///     <para>
+    ///         This method can be used to avoid large numbers in the numerator and denominator. However, be aware that the
+    ///         creation speed is significantly slower than using the pure value resulting from casting to double.
+    ///     </para>
+    /// </remarks>
+    /// <example>
+    ///     This example shows how to use the <see cref="FromDoubleRounded(double, int)" /> method.
+    ///     <code>
+    /// Fraction qv = Fraction.FromDoubleRounded(0.1, 15);
+    /// // Output: 1/10, which is exactly 0.1
+    /// </code>
+    /// </example>
+    public static Fraction FromDoubleRounded(double value, int nbSignificantDigits)
+    {
+        switch (value) {
+            case 0:
+                return Zero;
+            case double.NaN:
+                throw new InvalidNumberException("NaN values are not supported.");
+            case double.PositiveInfinity:
+                throw new InvalidNumberException("Positive infinity (+Infinity) is not supported.");
+            case double.NegativeInfinity:
+                throw new InvalidNumberException("Negative infinity (-Infinity) is not supported.");
+                
+        }
+
+        // Determine the number of decimal places to keep
+        var magnitude = Math.Floor(Math.Log10(Math.Abs(value)));
+        if (magnitude > nbSignificantDigits)
+        {
+            var digitsToKeep = new BigInteger(value / Math.Pow(10, magnitude - nbSignificantDigits));
+            return digitsToKeep * BigInteger.Pow(TEN, (int)magnitude - nbSignificantDigits);
+        }
+
+        // "decimal" values
+        var truncatedValue = Math.Truncate(value);
+        var integerPart = new BigInteger(truncatedValue);
+
+        var decimalPlaces = Math.Min(-(int)magnitude + nbSignificantDigits - 1, 308);
+        var scaleFactor = Math.Pow(10, decimalPlaces);
+        // Get the fractional part
+        var fractionalPartDouble = Math.Round((value - truncatedValue) * scaleFactor);
+        if (fractionalPartDouble == 0) // rounded to integer
+        {
+            return new Fraction(integerPart);
+        }
+
+        var denominator = BigInteger.Pow(TEN, decimalPlaces);
+        var numerator = integerPart * denominator + new BigInteger(fractionalPartDouble);
+        return new Fraction(numerator, denominator);
+    }
+    
 
     /// <summary>
     /// Converts a decimal value in a fraction. The value will not be rounded.

--- a/tests/Fractions.Tests/FractionSpecs/FromDouble/Method_FromDouble.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDouble/Method_FromDouble.cs
@@ -289,3 +289,20 @@ public class When_a_fraction_is_created_with_1_third : Spec {
         rounded.Should().Be(0.333333333333333);
     }
 }
+
+[TestFixture]
+public class When_a_fraction_is_created_from_double : Spec {
+
+    private const double ExpectedValue = 1.0 / (double.MaxValue - 100);
+
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = Fraction.FromDouble(ExpectedValue);
+    }
+
+    [Test]
+    public void ToDouble_does_not_always_return_the_same_value() {
+        _fraction.ToDouble().Should().NotBe(ExpectedValue);
+    }
+}

--- a/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
@@ -209,5 +210,116 @@ public class When_a_fraction_is_created_with_1_third : Spec {
     // German: Soll der Bruch danach einen Nenner von 3 haben
     public void The_fraction_should_then_have_a_denominator_of_3() {
         _fraction.Denominator.Should().Be(3);
+    }
+}
+
+[TestFixture]
+public class When_a_fractions_is_created_by_rounding_a_double_without_precision : Spec {
+    private const double DoubleValue = 1055.05585262;
+    private const decimal LiteralValue = 1055.05585262m; // the "true/literal" decimal representation
+
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = Fraction.FromDoubleRounded(DoubleValue);
+    }
+
+    [Test]
+    public void The_actual_fraction_may_differ_from_the_literal_value() {
+        LiteralValue.Should().Be((decimal)DoubleValue).And.NotBe(_fraction.ToDecimal());
+    }
+}
+
+[TestFixture]
+public class When_a_fractions_is_created_by_rounding_a_double_with_maximum_precision : Spec {
+    private const double DoubleValue = 1055.05585262;
+    private const decimal LiteralValue = 1055.05585262m; // the "true/literal" decimal representation
+    private const int MaxSignificantDigits = 15; // anything that's in the range [minRequiredPrecision, maxExpectedPrecision] should work
+
+    private Fraction _fraction;
+
+    public override void Act() {
+        _fraction = Fraction.FromDoubleRounded(DoubleValue, MaxSignificantDigits);
+    }
+
+    [Test]
+    public void The_actual_fraction_matches_the_literal_value() {
+        LiteralValue.Should().Be((decimal)DoubleValue).And.Be(_fraction.ToDecimal());
+    }
+}
+
+[TestFixture]
+public class When_a_fractions_is_created_by_rounding_a_double_with_reasonable_number_of_significant_digits : Spec {
+    private const int ReasonableNumberOfSignificantDigits = 15; // anything that's in the range [minRequiredPrecision, maxExpectedPrecision] should work 
+
+    private static IEnumerable<TestCaseData> TestCases { get; } = [
+        new TestCaseData(0.0, ReasonableNumberOfSignificantDigits).Returns(Fraction.Zero),
+        new TestCaseData(1.0, ReasonableNumberOfSignificantDigits).Returns(Fraction.One),
+        new TestCaseData(10.0, ReasonableNumberOfSignificantDigits).Returns(new Fraction(10m)),
+        new TestCaseData(-10.0, ReasonableNumberOfSignificantDigits).Returns(new Fraction(-10m)),
+        new TestCaseData(0.1, ReasonableNumberOfSignificantDigits).Returns(new Fraction(0.1m)),
+        new TestCaseData(-0.1, ReasonableNumberOfSignificantDigits).Returns(new Fraction(-0.1m)),
+        new TestCaseData(1055.05585262, 18).Returns(new Fraction(1055.05585262m)),
+        new TestCaseData(-1055.05585262, 18).Returns(new Fraction(-1055.05585262m))
+    ];
+
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public Fraction The_fraction_corresponds_to_the_rounded_decimal(double value, int significantDigits) {
+        return Fraction.FromDoubleRounded(value, significantDigits);
+    }
+}
+
+[TestFixture]
+public class When_a_fractions_is_created_by_rounding_a_double_with_exceeding_number_of_significant_digits : Spec {
+    private const double DoubleValue = 1055.05585262;
+    private const decimal LiteralValue = 1055.05585262m; // the "true/literal" decimal representation
+
+    [Test]
+    public void The_fraction_preserves_the_rounding_error() {
+        Fraction.FromDoubleRounded(DoubleValue, 19).ToDecimal()
+            .Should().BeApproximately(LiteralValue, 0.0001m).And.NotBe(LiteralValue);
+    }
+}
+
+[TestFixture]
+public class When_a_fractions_is_created_by_rounding_a_double_with_less_than_the_actual_significant_digits : Spec {
+    private static IEnumerable<TestCaseData> TestCases { get; } = [
+        new TestCaseData(1055.05585262, 0).Returns(new Fraction(1000m)),
+        new TestCaseData(-1055.05585262, 0).Returns(new Fraction(-1000m)),
+        new TestCaseData(1055.05585262, 1).Returns(new Fraction(1000m)),
+        new TestCaseData(-1055.05585262, 1).Returns(new Fraction(-1000m)),
+        new TestCaseData(1055.05585262, 2).Returns(new Fraction(1050m)),
+        new TestCaseData(-1055.05585262, 2).Returns(new Fraction(-1050m)),
+        new TestCaseData(1055.05585262, 3).Returns(new Fraction(1055m)),
+        new TestCaseData(-1055.05585262, 3).Returns(new Fraction(-1055m)),
+        new TestCaseData(1055.05585262, 4).Returns(new Fraction(1055m)),
+        new TestCaseData(-1055.05585262, 4).Returns(new Fraction(-1055m)),
+        new TestCaseData(1055.05585262, 5).Returns(new Fraction(1055.1m)),
+        new TestCaseData(-1055.05585262, 5).Returns(new Fraction(-1055.1m)),
+        new TestCaseData(1055.05585262, 6).Returns(new Fraction(1055.06m)),
+        new TestCaseData(-1055.05585262, 6).Returns(new Fraction(-1055.06m)),
+        new TestCaseData(1055.05585262, 7).Returns(new Fraction(1055.056m)),
+        new TestCaseData(-1055.05585262, 7).Returns(new Fraction(-1055.056m)),
+        new TestCaseData(1055.05585262, 8).Returns(new Fraction(1055.0559m)),
+        new TestCaseData(-1055.05585262, 8).Returns(new Fraction(-1055.0559m)),
+        new TestCaseData(1055.05585262, 9).Returns(new Fraction(1055.05585m)),
+        new TestCaseData(-1055.05585262, 9).Returns(new Fraction(-1055.05585m)),
+        new TestCaseData(1055.05585262, 10).Returns(new Fraction(1055.055853m)),
+        new TestCaseData(-1055.05585262, 10).Returns(new Fraction(-1055.055853m)),
+        new TestCaseData(1055.05585262, 11).Returns(new Fraction(1055.0558526m)),
+        new TestCaseData(-1055.05585262, 11).Returns(new Fraction(-1055.0558526m)),
+        new TestCaseData(1055.05585262, 12).Returns(new Fraction(1055.05585262m)),
+        new TestCaseData(-1055.05585262, 12).Returns(new Fraction(-1055.05585262m)),
+        new TestCaseData(1055.05585262, 13).Returns(new Fraction(1055.05585262m)),
+        new TestCaseData(-1055.05585262, 13).Returns(new Fraction(-1055.05585262m))
+    ];
+
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public Fraction The_fraction_is_rounded_to_the_specified_precision(double value, int significantDigits) {
+        return Fraction.FromDoubleRounded(value, significantDigits);
     }
 }


### PR DESCRIPTION
Sorry, there are two things being changed here, but I think you can see how they are related :
- `FromDouble`: refactored the code slightly, improving the performance on the negative cases (up to 10% according to my old benchmarks)
- `FromDoubleRounded(double value, int nbSignificantDigits)` :  added an overload that rounds the input up to the specified number of significant digits (which unlike the original `FromDoubleRounded` overload), produces a `Fraction` that corresponds to the "literal" value
- added tests to better illustrate the issues with rounding from binary to decimal representation (using the existing methods)
- added tests and benchmarks for the new overload
[results.zip](https://github.com/danm-de/Fractions/files/14962418/results.zip)
