### PR TITLE
adding net48 to the benchmark project targets

### DIFF
--- a/benchmarks/Fractions.Benchmarks/BasicMathBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/BasicMathBenchmarks.cs
@@ -1,10 +1,13 @@
 ﻿using System.Numerics;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 namespace Fractions.Benchmarks;
 
 [MemoryDiagnoser]
-[ShortRunJob]
+// [ShortRunJob]
+[ShortRunJob(RuntimeMoniker.Net48)]
+[ShortRunJob(RuntimeMoniker.Net80)]
 public class BasicMathBenchmarks {
     public static IEnumerable<object[]> Operands() {
         yield return [Fraction.Zero, Fraction.One];

--- a/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
@@ -34,8 +34,8 @@ public class ComparisonBenchmarks {
 
     [Benchmark]
     [ArgumentsSource(nameof(Operands))]
-    public int GetHashCode(Fraction a, Fraction b) {
-        return HashCode.Combine(a, b);
+    public bool GetHashCode(Fraction a, Fraction b) {
+        return a.GetHashCode() == b.GetHashCode();
     }
 
     [Benchmark]

--- a/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
+++ b/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/benchmarks/Fractions.Benchmarks/FromStringBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/FromStringBenchmarks.cs
@@ -1,10 +1,12 @@
 ﻿using System.Globalization;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 namespace Fractions.Benchmarks;
 
 [MemoryDiagnoser]
-[ShortRunJob]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
 public class FromStringBenchmarks {
 
     public static IEnumerable<string> ValidStrings => ["0", "1", "-1", "10242048", "1/5", "-1/5", "3.5", "-3.5", "1.2345678901234567890"];
@@ -15,22 +17,10 @@ public class FromStringBenchmarks {
     public bool TryParseValidString(string validString) {
         return Fraction.TryParse(validString, NumberStyles.Number, CultureInfo.InvariantCulture, false, out _);
     }
-
-    [Benchmark]
-    [ArgumentsSource(nameof(ValidStrings))]
-    public bool TryParseValidReadOnlySpan(string validString) {
-        return Fraction.TryParse(validString.AsSpan(), NumberStyles.Number, CultureInfo.InvariantCulture, false, out _);
-    }
     
     [Benchmark]
     [ArgumentsSource(nameof(InvalidStrings))]
     public bool TryParseInvalidString(string invalidString) {
         return Fraction.TryParse(invalidString, NumberStyles.Number, CultureInfo.InvariantCulture, false, out _);
-    }
-
-    [Benchmark]
-    [ArgumentsSource(nameof(InvalidStrings))]
-    public bool TryParseInvalidReadOnlySpan(string invalidString) {
-        return Fraction.TryParse(invalidString.AsSpan(), NumberStyles.Number, CultureInfo.InvariantCulture, false, out _);
     }
 }

--- a/benchmarks/results/Fractions.Benchmarks.BasicMathBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.BasicMathBenchmarks-report-github.md
@@ -3,82 +3,152 @@
 BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4291/22H2/2022Update)
 AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
 .NET SDK 8.0.204
-  [Host]   : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  ShortRun : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  [Host]                      : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET 8.0           : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9232.0), X64 RyuJIT VectorSize=256
 
-Job=ShortRun  IterationCount=3  LaunchCount=1  
-WarmupCount=3  
+IterationCount=3  LaunchCount=1  WarmupCount=3  
 
 ```
-| Method   | a                    | b                    | Mean       | Error      | StdDev    | Gen0   | Allocated |
-|--------- |--------------------- |--------------------- |-----------:|-----------:|----------:|-------:|----------:|
-| **Add**      | **-1000(...)00000 [39]** | **1/1000000000000**      |  **96.518 ns** |  **7.6135 ns** | **0.4173 ns** | **0.0076** |     **128 B** |
-| Subtract | -1000(...)00000 [39] | 1/1000000000000      |  92.135 ns | 12.9212 ns | 0.7083 ns | 0.0076 |     128 B |
-| Multiply | -1000(...)00000 [39] | 1/1000000000000      | 105.635 ns | 12.7243 ns | 0.6975 ns | 0.0086 |     144 B |
-| Divide   | -1000(...)00000 [39] | 1/1000000000000      |  48.106 ns |  1.4969 ns | 0.0821 ns | 0.0029 |      48 B |
-| Mod      | -1000(...)00000 [39] | 1/1000000000000      |  63.399 ns |  3.3933 ns | 0.1860 ns | 0.0048 |      80 B |
-| **Add**      | **-1024**                | **-1/1024**              |  **39.779 ns** |  **1.5791 ns** | **0.0866 ns** |      **-** |         **-** |
-| Subtract | -1024                | -1/1024              |  42.910 ns |  1.3106 ns | 0.0718 ns |      - |         - |
-| Multiply | -1024                | -1/1024              |  29.098 ns |  1.1837 ns | 0.0649 ns |      - |         - |
-| Divide   | -1024                | -1/1024              |  21.122 ns |  7.4146 ns | 0.4064 ns |      - |         - |
-| Mod      | -1024                | -1/1024              |  29.273 ns |  1.8908 ns | 0.1036 ns |      - |         - |
-| **Add**      | **-45**                  | **1/6**                  |  **40.607 ns** |  **2.9460 ns** | **0.1615 ns** |      **-** |         **-** |
-| Subtract | -45                  | 1/6                  |  40.916 ns |  0.2777 ns | 0.0152 ns |      - |         - |
-| Multiply | -45                  | 1/6                  |  30.822 ns |  3.2140 ns | 0.1762 ns |      - |         - |
-| Divide   | -45                  | 1/6                  |  19.865 ns |  0.8168 ns | 0.0448 ns |      - |         - |
-| Mod      | -45                  | 1/6                  |  28.453 ns |  2.2326 ns | 0.1224 ns |      - |         - |
-| **Add**      | **0**                    | **1**                    |   **6.399 ns** |  **0.3507 ns** | **0.0192 ns** |      **-** |         **-** |
-| Subtract | 0                    | 1                    |   8.699 ns |  0.4104 ns | 0.0225 ns |      - |         - |
-| Multiply | 0                    | 1                    |   6.166 ns |  0.6625 ns | 0.0363 ns |      - |         - |
-| Divide   | 0                    | 1                    |   8.224 ns |  0.3850 ns | 0.0211 ns |      - |         - |
-| Mod      | 0                    | 1                    |   5.443 ns |  0.2658 ns | 0.0146 ns |      - |         - |
-| **Add**      | **27/200**               | **19/250**               |  **57.197 ns** |  **2.9670 ns** | **0.1626 ns** |      **-** |         **-** |
-| Subtract | 27/200               | 19/250               |  56.734 ns |  3.4141 ns | 0.1871 ns |      - |         - |
-| Multiply | 27/200               | 19/250               |  32.059 ns |  0.5360 ns | 0.0294 ns |      - |         - |
-| Divide   | 27/200               | 19/250               |  37.671 ns |  1.1920 ns | 0.0653 ns |      - |         - |
-| Mod      | 27/200               | 19/250               |  54.724 ns |  6.5216 ns | 0.3575 ns |      - |         - |
-| **Add**      | **42/66**                | **36/96**                |  **58.200 ns** |  **3.9442 ns** | **0.2162 ns** |      **-** |         **-** |
-| Subtract | 42/66                | 36/96                |  65.737 ns |  5.6027 ns | 0.3071 ns |      - |         - |
-| Multiply | 42/66                | 36/96                |  34.961 ns |  5.5155 ns | 0.3023 ns |      - |         - |
-| Divide   | 42/66                | 36/96                |  36.864 ns |  0.3512 ns | 0.0192 ns |      - |         - |
-| Mod      | 42/66                | 36/96                |  69.171 ns |  6.8273 ns | 0.3742 ns |      - |         - |
-| **Add**      | **88427(...)10656 [31]** | **47161(...)70496 [33]** | **171.376 ns** |  **8.9383 ns** | **0.4899 ns** | **0.0095** |     **160 B** |
-| Subtract | 88427(...)10656 [31] | 47161(...)70496 [33] | 166.359 ns |  4.3265 ns | 0.2371 ns | 0.0095 |     160 B |
-| Multiply | 88427(...)10656 [31] | 47161(...)70496 [33] | 269.679 ns |  9.9033 ns | 0.5428 ns | 0.0048 |      80 B |
-| Divide   | 88427(...)10656 [31] | 47161(...)70496 [33] | 146.775 ns | 17.3043 ns | 0.9485 ns | 0.0105 |     176 B |
-| Mod      | 88427(...)10656 [31] | 47161(...)70496 [33] | 113.024 ns | 17.5619 ns | 0.9626 ns | 0.0076 |     128 B |
-| **Add**      | **88427(...)10656 [31]** | **88427(...)21312 [31]** | **154.861 ns** | **19.1600 ns** | **1.0502 ns** | **0.0095** |     **160 B** |
-| Subtract | 88427(...)10656 [31] | 88427(...)21312 [31] | 167.509 ns |  4.4677 ns | 0.2449 ns | 0.0095 |     160 B |
-| Multiply | 88427(...)10656 [31] | 88427(...)21312 [31] | 214.677 ns | 18.2085 ns | 0.9981 ns | 0.0048 |      80 B |
-| Divide   | 88427(...)10656 [31] | 88427(...)21312 [31] | 111.984 ns | 11.1031 ns | 0.6086 ns | 0.0072 |     120 B |
-| Mod      | 88427(...)10656 [31] | 88427(...)21312 [31] | 108.401 ns |  8.0908 ns | 0.4435 ns | 0.0076 |     128 B |
-| **Add**      | **245850922/78256779**   | **NaN**                  |   **6.086 ns** |  **1.3360 ns** | **0.0732 ns** |      **-** |         **-** |
-| Subtract | 245850922/78256779   | NaN                  |   8.773 ns |  1.9249 ns | 0.1055 ns |      - |         - |
-| Multiply | 245850922/78256779   | NaN                  |   8.131 ns |  0.7038 ns | 0.0386 ns |      - |         - |
-| Divide   | 245850922/78256779   | NaN                  |   5.277 ns |  0.5477 ns | 0.0300 ns |      - |         - |
-| Mod      | 245850922/78256779   | NaN                  |   5.585 ns |  0.6494 ns | 0.0356 ns |      - |         - |
-| **Add**      | **245850922/78256779**   | **-∞**                   |   **7.354 ns** |  **1.3069 ns** | **0.0716 ns** |      **-** |         **-** |
-| Subtract | 245850922/78256779   | -∞                   |   9.764 ns |  2.6043 ns | 0.1428 ns |      - |         - |
-| Multiply | 245850922/78256779   | -∞                   |   8.410 ns |  3.4697 ns | 0.1902 ns |      - |         - |
-| Divide   | 245850922/78256779   | -∞                   |   5.417 ns |  0.1907 ns | 0.0105 ns |      - |         - |
-| Mod      | 245850922/78256779   | -∞                   |   6.474 ns |  0.2077 ns | 0.0114 ns |      - |         - |
-| **Add**      | **245850922/78256779**   | **0**                    |   **6.120 ns** |  **0.7352 ns** | **0.0403 ns** |      **-** |         **-** |
-| Subtract | 245850922/78256779   | 0                    |   7.751 ns |  0.8057 ns | 0.0442 ns |      - |         - |
-| Multiply | 245850922/78256779   | 0                    |   6.848 ns |  2.4247 ns | 0.1329 ns |      - |         - |
-| Divide   | 245850922/78256779   | 0                    |   7.898 ns |  0.6797 ns | 0.0373 ns |      - |         - |
-| Mod      | 245850922/78256779   | 0                    |   5.378 ns |  0.5986 ns | 0.0328 ns |      - |         - |
-| **Add**      | **245850922/78256779**   | **26714619/25510582**    | **134.649 ns** |  **4.8332 ns** | **0.2649 ns** | **0.0076** |     **128 B** |
-| Subtract | 245850922/78256779   | 26714619/25510582    | 126.839 ns |  8.9179 ns | 0.4888 ns | 0.0076 |     128 B |
-| Multiply | 245850922/78256779   | 26714619/25510582    | 114.216 ns | 16.8179 ns | 0.9218 ns | 0.0076 |     128 B |
-| Divide   | 245850922/78256779   | 26714619/25510582    |  40.298 ns |  5.5067 ns | 0.3018 ns | 0.0038 |      64 B |
-| Mod      | 245850922/78256779   | 26714619/25510582    |  69.081 ns |  3.9803 ns | 0.2182 ns | 0.0057 |      96 B |
-| **Add**      | **245850922/78256779**   | **122925461/78256779**   |  **56.312 ns** |  **2.1974 ns** | **0.1204 ns** |      **-** |         **-** |
-| Subtract | 245850922/78256779   | 122925461/78256779   |  47.589 ns |  3.5065 ns | 0.1922 ns |      - |         - |
-| Multiply | 245850922/78256779   | 122925461/78256779   |  85.453 ns |  6.2655 ns | 0.3434 ns | 0.0038 |      64 B |
-| Divide   | 245850922/78256779   | 122925461/78256779   |  72.555 ns |  4.1240 ns | 0.2261 ns | 0.0057 |      96 B |
-| Mod      | 245850922/78256779   | 122925461/78256779   |  42.300 ns |  2.7280 ns | 0.1495 ns |      - |         - |
-| **Add**      | **42/-96**               | **36/-96**               |  **31.684 ns** |  **8.2956 ns** | **0.4547 ns** |      **-** |         **-** |
-| Subtract | 42/-96               | 36/-96               |  29.886 ns |  3.3185 ns | 0.1819 ns |      - |         - |
-| Multiply | 42/-96               | 36/-96               |  35.319 ns |  1.3069 ns | 0.0716 ns |      - |         - |
-| Divide   | 42/-96               | 36/-96               |  32.314 ns |  2.0923 ns | 0.1147 ns |      - |         - |
-| Mod      | 42/-96               | 36/-96               |  56.156 ns |  3.9477 ns | 0.2164 ns |      - |         - |
+| Method   | Job                         | Runtime            | a                    | b                    | Mean       | Error       | StdDev     | Gen0   | Allocated |
+|--------- |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|------------:|-----------:|-------:|----------:|
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/-96**               | **36/-96**               |  **31.017 ns** |   **0.7358 ns** |  **0.0403 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  29.988 ns |   0.9883 ns |  0.0542 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  35.176 ns |   0.4940 ns |  0.0271 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  32.002 ns |   0.9930 ns |  0.0544 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  56.452 ns |  10.8543 ns |  0.5950 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 115.984 ns |   6.8251 ns |  0.3741 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 137.489 ns |   7.8941 ns |  0.4327 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 145.582 ns |  41.3267 ns |  2.2653 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 140.115 ns | 115.2926 ns |  6.3196 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 283.314 ns |  85.2938 ns |  4.6752 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)00000 [39]** | **1/1000000000000**      |  **95.125 ns** |  **11.5045 ns** |  **0.6306 ns** | **0.0076** |     **128 B** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  90.583 ns |   4.6566 ns |  0.2552 ns | 0.0076 |     128 B |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      | 104.996 ns |   7.8963 ns |  0.4328 ns | 0.0086 |     144 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  48.550 ns |   2.1223 ns |  0.1163 ns | 0.0029 |      48 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  62.099 ns |  12.4717 ns |  0.6836 ns | 0.0048 |      80 B |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 258.742 ns |   7.7874 ns |  0.4269 ns | 0.0229 |     144 B |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 265.737 ns |  35.7137 ns |  1.9576 ns | 0.0229 |     144 B |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 222.409 ns |  23.4409 ns |  1.2849 ns | 0.0293 |     185 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 139.956 ns |  13.0163 ns |  0.7135 ns | 0.0153 |      96 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 162.653 ns |   6.0178 ns |  0.3299 ns | 0.0076 |      48 B |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024**                | **-1/1024**              |  **39.822 ns** |   **0.9912 ns** |  **0.0543 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  42.969 ns |   0.9741 ns |  0.0534 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  28.642 ns |   3.0397 ns |  0.1666 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  21.054 ns |   6.2133 ns |  0.3406 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  28.900 ns |   0.6902 ns |  0.0378 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 174.975 ns |   6.2386 ns |  0.3420 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 193.501 ns |   7.9909 ns |  0.4380 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 125.419 ns |  29.8708 ns |  1.6373 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 101.735 ns |  14.0143 ns |  0.7682 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 120.512 ns |   5.3187 ns |  0.2915 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45**                  | **1/6**                  |  **40.785 ns** |   **2.8007 ns** |  **0.1535 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  40.510 ns |   1.3158 ns |  0.0721 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  31.392 ns |   3.7824 ns |  0.2073 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  19.683 ns |   0.2862 ns |  0.0157 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  28.435 ns |   5.4581 ns |  0.2992 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 171.493 ns |   9.0034 ns |  0.4935 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 179.977 ns |  18.8823 ns |  1.0350 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 124.787 ns |  17.7712 ns |  0.9741 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  99.195 ns |   2.0830 ns |  0.1142 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 117.900 ns |  53.1273 ns |  2.9121 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0**                    | **1**                    |   **6.033 ns** |   **0.3368 ns** |  **0.0185 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   8.428 ns |   1.1827 ns |  0.0648 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   7.358 ns |   2.2039 ns |  0.1208 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   8.126 ns |   0.9422 ns |  0.0516 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   5.590 ns |   0.0902 ns |  0.0049 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  23.503 ns |   0.4834 ns |  0.0265 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  34.708 ns |   0.5195 ns |  0.0285 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  26.744 ns |   3.5304 ns |  0.1935 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  28.128 ns |   1.7300 ns |  0.0948 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  27.584 ns |   0.6504 ns |  0.0357 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **57.335 ns** |  **10.3454 ns** |  **0.5671 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  56.491 ns |  12.7089 ns |  0.6966 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  31.714 ns |   1.5954 ns |  0.0874 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  36.659 ns |   0.2012 ns |  0.0110 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  54.477 ns |   7.9886 ns |  0.4379 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 230.200 ns |  33.4819 ns |  1.8353 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 230.266 ns |  58.4852 ns |  3.2058 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 101.229 ns |  10.6455 ns |  0.5835 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 142.277 ns | 118.5358 ns |  6.4973 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 234.805 ns |  26.1707 ns |  1.4345 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/66**                | **36/96**                |  **60.230 ns** |  **61.3454 ns** |  **3.3626 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  66.067 ns |  22.4577 ns |  1.2310 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  35.101 ns |   5.0603 ns |  0.2774 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  37.139 ns |   5.2317 ns |  0.2868 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  69.936 ns |  33.3710 ns |  1.8292 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 267.731 ns |  90.6379 ns |  4.9682 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 274.703 ns |  36.2682 ns |  1.9880 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 138.299 ns |  30.9047 ns |  1.6940 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 140.804 ns |  28.6482 ns |  1.5703 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 283.028 ns | 232.5598 ns | 12.7474 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **47161(...)70496 [33]** | **171.990 ns** |  **18.7223 ns** |  **1.0262 ns** | **0.0095** |     **160 B** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 47161(...)70496 [33] | 168.041 ns |   8.7757 ns |  0.4810 ns | 0.0095 |     160 B |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 47161(...)70496 [33] | 272.716 ns |  42.4874 ns |  2.3289 ns | 0.0048 |      80 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 47161(...)70496 [33] | 156.066 ns |  51.3617 ns |  2.8153 ns | 0.0105 |     176 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 47161(...)70496 [33] | 119.617 ns |  18.3588 ns |  1.0063 ns | 0.0076 |     128 B |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 47161(...)70496 [33] | 304.821 ns |  44.3093 ns |  2.4287 ns | 0.0277 |     177 B |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 47161(...)70496 [33] | 354.854 ns |  50.1433 ns |  2.7485 ns | 0.0267 |     168 B |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 47161(...)70496 [33] | 159.729 ns |  19.8501 ns |  1.0880 ns | 0.0126 |      80 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 47161(...)70496 [33] | 313.811 ns |  37.0886 ns |  2.0329 ns | 0.0482 |     305 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 47161(...)70496 [33] | 365.414 ns |  25.2207 ns |  1.3824 ns | 0.0267 |     168 B |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **88427(...)21312 [31]** | **154.863 ns** |   **2.8119 ns** |  **0.1541 ns** | **0.0095** |     **160 B** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 166.475 ns |  15.0070 ns |  0.8226 ns | 0.0095 |     160 B |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 213.422 ns |  11.6776 ns |  0.6401 ns | 0.0048 |      80 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 112.040 ns |   2.4414 ns |  0.1338 ns | 0.0072 |     120 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 108.012 ns |   7.6213 ns |  0.4178 ns | 0.0076 |     128 B |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 306.389 ns |  28.1251 ns |  1.5416 ns | 0.0277 |     177 B |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 318.183 ns |   3.0448 ns |  0.1669 ns | 0.0267 |     168 B |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 161.847 ns |   2.6492 ns |  0.1452 ns | 0.0126 |      80 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 291.165 ns |  11.2720 ns |  0.6179 ns | 0.0443 |     281 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 323.224 ns |  21.5532 ns |  1.1814 ns | 0.0267 |     168 B |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **6.156 ns** |   **0.4853 ns** |  **0.0266 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   9.219 ns |   6.3637 ns |  0.3488 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   8.001 ns |   3.1076 ns |  0.1703 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   5.360 ns |   1.1677 ns |  0.0640 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   6.443 ns |   0.3631 ns |  0.0199 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  23.389 ns |   1.5482 ns |  0.0849 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  35.074 ns |   1.2161 ns |  0.0667 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  31.042 ns |   8.6603 ns |  0.4747 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  24.498 ns |   1.3851 ns |  0.0759 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  27.602 ns |   4.2110 ns |  0.2308 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **7.050 ns** |   **1.1385 ns** |  **0.0624 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   9.906 ns |   6.5867 ns |  0.3610 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   7.889 ns |   3.1057 ns |  0.1702 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   5.548 ns |   5.2341 ns |  0.2869 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   6.535 ns |   0.3927 ns |  0.0215 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  27.234 ns |   2.4259 ns |  0.1330 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  38.321 ns |   0.0784 ns |  0.0043 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  30.230 ns |   0.6095 ns |  0.0334 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  24.705 ns |   2.2934 ns |  0.1257 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  25.966 ns |   2.4605 ns |  0.1349 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **6.222 ns** |   **0.1861 ns** |  **0.0102 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.995 ns |   0.9655 ns |  0.0529 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.295 ns |   0.9820 ns |  0.0538 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   8.136 ns |   0.6550 ns |  0.0359 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   5.894 ns |   5.2164 ns |  0.2859 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  24.191 ns |   0.1401 ns |  0.0077 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  35.023 ns |  20.3820 ns |  1.1172 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  27.555 ns |   7.7288 ns |  0.4236 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  31.740 ns |   3.0042 ns |  0.1647 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  27.662 ns |   6.2118 ns |  0.3405 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **26714619/25510582**    | **134.367 ns** |   **9.7171 ns** |  **0.5326 ns** | **0.0076** |     **128 B** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 26714619/25510582    | 126.783 ns |   9.7645 ns |  0.5352 ns | 0.0076 |     128 B |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 26714619/25510582    | 113.947 ns |   2.4109 ns |  0.1321 ns | 0.0076 |     128 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 26714619/25510582    |  38.420 ns |   5.0431 ns |  0.2764 ns | 0.0038 |      64 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 26714619/25510582    |  68.864 ns |   9.5322 ns |  0.5225 ns | 0.0057 |      96 B |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 26714619/25510582    | 267.413 ns | 165.1211 ns |  9.0508 ns | 0.0215 |     136 B |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 26714619/25510582    | 268.897 ns |  14.1283 ns |  0.7744 ns | 0.0200 |     128 B |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 26714619/25510582    | 217.313 ns | 176.0046 ns |  9.6474 ns | 0.0203 |     128 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 26714619/25510582    | 113.036 ns | 128.4444 ns |  7.0405 ns | 0.0100 |      64 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 26714619/25510582    | 211.664 ns |  49.9236 ns |  2.7365 ns | 0.0203 |     128 B |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **122925461/78256779**   |  **56.581 ns** |   **0.9009 ns** |  **0.0494 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 122925461/78256779   |  47.287 ns |   5.7837 ns |  0.3170 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 122925461/78256779   |  87.667 ns |  41.0323 ns |  2.2491 ns | 0.0038 |      64 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 122925461/78256779   |  75.435 ns |  74.8310 ns |  4.1017 ns | 0.0057 |      96 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 122925461/78256779   |  42.018 ns |  15.1846 ns |  0.8323 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 122925461/78256779   | 148.841 ns |  16.8174 ns |  0.9218 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 122925461/78256779   | 126.072 ns |   8.9020 ns |  0.4879 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 122925461/78256779   | 139.187 ns |  11.7769 ns |  0.6455 ns | 0.0100 |      64 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 122925461/78256779   | 223.359 ns |  35.4521 ns |  1.9433 ns | 0.0253 |     160 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 122925461/78256779   | 186.499 ns |   7.9663 ns |  0.4367 ns |      - |         - |

--- a/benchmarks/results/Fractions.Benchmarks.FromStringBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.FromStringBenchmarks-report-github.md
@@ -3,38 +3,37 @@
 BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4291/22H2/2022Update)
 AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
 .NET SDK 8.0.204
-  [Host]   : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  ShortRun : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  [Host]             : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  .NET 8.0           : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  .NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9232.0), X64 RyuJIT VectorSize=256
 
-Job=ShortRun  IterationCount=3  LaunchCount=1  
-WarmupCount=3  
 
 ```
-| Method                      | invalidString        | validString          | Mean      | Error     | StdDev   | Gen0   | Allocated |
-|---------------------------- |--------------------- |--------------------- |----------:|----------:|---------:|-------:|----------:|
-| **TryParseInvalidString**       | ****                     | **?**                    |  **29.48 ns** |  **2.456 ns** | **0.135 ns** | **0.0081** |     **136 B** |
-| TryParseInvalidReadOnlySpan |                      | ?                    |  33.93 ns |  4.411 ns | 0.242 ns | 0.0086 |     144 B |
-| **TryParseValidString**         | **?**                    | **-1**                   |  **56.36 ns** |  **3.310 ns** | **0.181 ns** | **0.0081** |     **136 B** |
-| TryParseValidReadOnlySpan   | ?                    | -1                   |  60.22 ns |  2.503 ns | 0.137 ns | 0.0086 |     144 B |
-| **TryParseValidString**         | **?**                    | **-1/5**                 |  **96.34 ns** |  **7.234 ns** | **0.397 ns** | **0.0181** |     **304 B** |
-| TryParseValidReadOnlySpan   | ?                    | -1/5                 |  88.55 ns | 20.557 ns | 1.127 ns | 0.0148 |     248 B |
-| **TryParseInvalidString**       | **-10242048/**           | **?**                    |  **88.16 ns** |  **7.502 ns** | **0.411 ns** | **0.0172** |     **288 B** |
-| TryParseInvalidReadOnlySpan | -10242048/           | ?                    |  85.39 ns |  7.891 ns | 0.433 ns | 0.0148 |     248 B |
-| **TryParseValidString**         | **?**                    | **-3.5**                 |  **79.94 ns** | **14.519 ns** | **0.796 ns** | **0.0100** |     **168 B** |
-| TryParseValidReadOnlySpan   | ?                    | -3.5                 |  84.49 ns | 27.339 ns | 1.499 ns | 0.0105 |     176 B |
-| **TryParseValidString**         | **?**                    | **0**                    |  **52.81 ns** |  **9.045 ns** | **0.496 ns** | **0.0081** |     **136 B** |
-| TryParseValidReadOnlySpan   | ?                    | 0                    |  58.10 ns | 10.521 ns | 0.577 ns | 0.0086 |     144 B |
-| **TryParseValidString**         | **?**                    | **1**                    |  **59.39 ns** |  **7.918 ns** | **0.434 ns** | **0.0081** |     **136 B** |
-| TryParseValidReadOnlySpan   | ?                    | 1                    |  63.52 ns | 11.646 ns | 0.638 ns | 0.0086 |     144 B |
-| **TryParseValidString**         | **?**                    | **1.234(...)67890 [21]** | **310.55 ns** | **53.211 ns** | **2.917 ns** | **0.0257** |     **432 B** |
-| TryParseValidReadOnlySpan   | ?                    | 1.234(...)67890 [21] | 328.02 ns | 90.127 ns | 4.940 ns | 0.0262 |     440 B |
-| **TryParseInvalidString**       | **1.234(...)7890f [22]** | **?**                    |  **99.22 ns** | **11.087 ns** | **0.608 ns** | **0.0181** |     **304 B** |
-| TryParseInvalidReadOnlySpan | 1.234(...)7890f [22] | ?                    | 110.23 ns | 25.623 ns | 1.404 ns | 0.0186 |     312 B |
-| **TryParseValidString**         | **?**                    | **1/5**                  |  **98.17 ns** |  **6.198 ns** | **0.340 ns** | **0.0176** |     **296 B** |
-| TryParseValidReadOnlySpan   | ?                    | 1/5                  |  85.42 ns |  3.685 ns | 0.202 ns | 0.0148 |     248 B |
-| **TryParseValidString**         | **?**                    | **10242048**             |  **76.23 ns** | **24.176 ns** | **1.325 ns** | **0.0081** |     **136 B** |
-| TryParseValidReadOnlySpan   | ?                    | 10242048             |  80.76 ns |  6.534 ns | 0.358 ns | 0.0086 |     144 B |
-| **TryParseValidString**         | **?**                    | **3.5**                  |  **83.27 ns** | **28.197 ns** | **1.546 ns** | **0.0100** |     **168 B** |
-| TryParseValidReadOnlySpan   | ?                    | 3.5                  |  86.50 ns |  9.325 ns | 0.511 ns | 0.0105 |     176 B |
-| **TryParseInvalidString**       | **invalid**              | **?**                    |  **38.63 ns** |  **9.891 ns** | **0.542 ns** | **0.0081** |     **136 B** |
-| TryParseInvalidReadOnlySpan | invalid              | ?                    |  41.43 ns | 14.066 ns | 0.771 ns | 0.0086 |     144 B |
+| Method                | Job                | Runtime            | invalidString        | validString          | Mean        | Error    | StdDev   | Gen0   | Allocated |
+|---------------------- |------------------- |------------------- |--------------------- |--------------------- |------------:|---------:|---------:|-------:|----------:|
+| **TryParseInvalidString** | **.NET 8.0**           | **.NET 8.0**           | ****                     | **?**                    |    **32.16 ns** | **0.304 ns** | **0.284 ns** | **0.0081** |     **136 B** |
+| TryParseInvalidString | .NET Framework 4.8 | .NET Framework 4.8 |                      | ?                    |   123.03 ns | 1.264 ns | 1.182 ns | 0.0610 |     385 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **-1**                   |    **60.50 ns** | **0.400 ns** | **0.374 ns** | **0.0081** |     **136 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | -1                   |   191.76 ns | 1.852 ns | 1.732 ns | 0.0625 |     393 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **-1/5**                 |    **98.79 ns** | **0.819 ns** | **0.766 ns** | **0.0181** |     **304 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | -1/5                 |   199.26 ns | 1.588 ns | 1.485 ns | 0.0610 |     385 B |
+| **TryParseInvalidString** | **.NET 8.0**           | **.NET 8.0**           | **-10242048/**           | **?**                    |    **86.54 ns** | **0.817 ns** | **0.724 ns** | **0.0172** |     **288 B** |
+| TryParseInvalidString | .NET Framework 4.8 | .NET Framework 4.8 | -10242048/           | ?                    |   426.30 ns | 1.573 ns | 1.471 ns | 0.0625 |     393 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **-3.5**                 |    **79.19 ns** | **0.486 ns** | **0.406 ns** | **0.0100** |     **168 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | -3.5                 |   349.30 ns | 2.129 ns | 1.992 ns | 0.0787 |     497 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **0**                    |    **57.50 ns** | **0.446 ns** | **0.417 ns** | **0.0081** |     **136 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | 0                    |   160.82 ns | 1.124 ns | 1.051 ns | 0.0625 |     393 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **1**                    |    **59.75 ns** | **0.278 ns** | **0.247 ns** | **0.0081** |     **136 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | 1                    |   191.25 ns | 1.319 ns | 1.169 ns | 0.0625 |     393 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **1.234(...)67890 [21]** |   **303.05 ns** | **1.305 ns** | **1.157 ns** | **0.0257** |     **432 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | 1.234(...)67890 [21] | 1,694.03 ns | 8.369 ns | 6.988 ns | 0.2556 |    1613 B |
+| **TryParseInvalidString** | **.NET 8.0**           | **.NET 8.0**           | **1.234(...)7890f [22]** | **?**                    |   **101.26 ns** | **1.050 ns** | **0.982 ns** | **0.0181** |     **304 B** |
+| TryParseInvalidString | .NET Framework 4.8 | .NET Framework 4.8 | 1.234(...)7890f [22] | ?                    |   241.97 ns | 0.758 ns | 0.672 ns | 0.1197 |     754 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **1/5**                  |    **93.78 ns** | **0.817 ns** | **0.765 ns** | **0.0176** |     **296 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | 1/5                  |   197.88 ns | 0.825 ns | 0.731 ns | 0.0610 |     385 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **10242048**             |    **77.34 ns** | **0.217 ns** | **0.181 ns** | **0.0081** |     **136 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | 10242048             |   474.95 ns | 3.166 ns | 2.961 ns | 0.0663 |     417 B |
+| **TryParseValidString**   | **.NET 8.0**           | **.NET 8.0**           | **?**                    | **3.5**                  |    **79.82 ns** | **0.354 ns** | **0.331 ns** | **0.0100** |     **168 B** |
+| TryParseValidString   | .NET Framework 4.8 | .NET Framework 4.8 | ?                    | 3.5                  |   333.29 ns | 1.649 ns | 1.377 ns | 0.0787 |     497 B |
+| **TryParseInvalidString** | **.NET 8.0**           | **.NET 8.0**           | **invalid**              | **?**                    |    **38.08 ns** | **0.421 ns** | **0.394 ns** | **0.0081** |     **136 B** |
+| TryParseInvalidString | .NET Framework 4.8 | .NET Framework 4.8 | invalid              | ?                    |   145.76 ns | 1.339 ns | 1.187 ns | 0.0663 |     417 B |


### PR DESCRIPTION
- updating the `FromString` benchmarks (multi-target)
- updating the results for `FromString` and `BasicMath` (multi-target)

I've got some very interesting charts, please merge this before the PR for #56 so that it would be easier to compare (I've got the same set of results there as well).

.. more info to come