### PR TITLE
Adding a debugger display proxy

### DIFF
--- a/src/Fractions/Formatter/DecimalNotationFormatter.cs
+++ b/src/Fractions/Formatter/DecimalNotationFormatter.cs
@@ -72,7 +72,7 @@ public class DecimalNotationFormatter : ICustomFormatter {
     /// <remarks>
     ///     This instance can be used to format Fraction objects into decimal string representations.
     /// </remarks>
-    public static ICustomFormatter Instance { get; } = new DecimalNotationFormatter();
+    public static DecimalNotationFormatter Instance { get; } = new();
 
     private static readonly BigInteger Ten = new(10);
 

--- a/src/Fractions/Fraction.DebugProxy.cs
+++ b/src/Fractions/Fraction.DebugProxy.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using System.Numerics;
+using Fractions.Formatter;
+
+namespace Fractions;
+
+public readonly partial struct Fraction {
+    internal readonly struct FractionDebugView(Fraction fraction) {
+        public BigInteger A => fraction.Numerator;
+        public BigInteger B => fraction.Denominator;
+        public FractionState State => fraction.State;
+        public StringFormatsView StringFormats => new(fraction);
+        public NumericFormatsView ValueFormats => new(fraction);
+
+        [DebuggerDisplay("{ShortFormat}")]
+        internal readonly struct StringFormatsView(Fraction fraction) {
+            public string GeneralFormat => DecimalNotationFormatter.Instance.Format("g", fraction, CultureInfo.CurrentCulture);
+            public string ShortFormat => DecimalNotationFormatter.Instance.Format("s", fraction, CultureInfo.CurrentCulture);
+            public string SimplifiedFraction => fraction.ToString("m");
+        }
+
+        [DebuggerDisplay("{Double}")]
+        internal readonly struct NumericFormatsView(Fraction fraction) {
+            public int Integer => fraction.ToInt32();
+            public long Long => fraction.ToInt64();
+            public decimal Decimal => fraction.ToDecimal();
+            public double Double => fraction.ToDouble();
+        }
+    }
+}

--- a/src/Fractions/Fraction.cs
+++ b/src/Fractions/Fraction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using Fractions.TypeConverters;
@@ -12,6 +13,7 @@ namespace Fractions;
 /// </summary>
 [TypeConverter(typeof(FractionTypeConverter))]
 [StructLayout(LayoutKind.Sequential)]
+[DebuggerTypeProxy(typeof(FractionDebugView))]
 public readonly partial struct Fraction : IEquatable<Fraction>, IComparable, IComparable<Fraction>, IFormattable {
     private static readonly BigInteger TEN = new(10);
 


### PR DESCRIPTION
Here's what I was thinking:

![image](https://github.com/danm-de/Fractions/assets/5253184/ac8ccefa-b6ef-4558-8803-7d3892c86902)

I haven't changed the top-level display (which defaults to the ToString()) implementation, however if we wanted, we could make this some kind of internal `ToShortString()` implementation which uses the decimal notation, when possible, switching to the "a/b" format (or possibly the "m" version) otherwise. 