### PR TITLE
Feature/default to value equality

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,8 @@
 
 ### Breaking changes
 
-- Mathematical operations no longer automatically generate normalized fractions if one of the operands is an improper (i.e. non-normalized) fraction. This has an impact on your calculations, especially if you have used the `JsonFractionConverter` with default settings. In such cases, deserialized fractions create improper fractions, which can lead to changed behavior when calling `Equals` and `ToString`. Please refer the README section [Working with non-normalized fractions](Readme.md#working-with-non-normalized-fractions)
+- Mathematical operations no longer automatically generate normalized fractions if one of the operands is an improper (i.e. non-normalized) fraction. This has an impact on your calculations, especially if you have used the `JsonFractionConverter` with default settings. In such cases, deserialized fractions create improper fractions, which can lead to changed behavior when calling `ToString`. Please refer the README section [Working with non-normalized fractions](Readme.md#working-with-non-normalized-fractions)
+- The default behavior of the `.Equals(Fraction)` method has changed: `Equals` now compares the calculated value from the numerator/denominator (1/2 = 2/4).
 - The standard function `ToString()` now depends on the active culture (`CultureInfo.CurrentCulture`). The reason is that NaN and Infinity should be displayed in the system language or the corresponding symbol should be used.
 - Argument name for `Fraction.TryParse(..)` changed from `fractionString` to `value`.
 - A fraction of 0/0 no longer has the value 0, but means NaN (not a number). Any fraction in the form x/0 is no longer a valid number. A denominator with the value 0 corresponds to, depending on the numerator, NaN, PositiveInfinity or NegativeInfinity.

--- a/Fractions.sln
+++ b/Fractions.sln
@@ -43,6 +43,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Results", "Results", "{FCF0
 		benchmarks\results\Fractions.Benchmarks.ExampleScenarioBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.ExampleScenarioBenchmarks-report-github.md
 		benchmarks\results\Fractions.Benchmarks.FromDoubleBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.FromDoubleBenchmarks-report-github.md
 		benchmarks\results\Fractions.Benchmarks.FromStringBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.FromStringBenchmarks-report-github.md
+		benchmarks\results\Fractions.Benchmarks.NonNormalizedComparisonBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.NonNormalizedComparisonBenchmarks-report-github.md
 		benchmarks\results\Fractions.Benchmarks.NonNormalizedMathBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.NonNormalizedMathBenchmarks-report-github.md
 		benchmarks\results\Fractions.Benchmarks.PowerMathBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.PowerMathBenchmarks-report-github.md
 		benchmarks\results\Fractions.Benchmarks.ToStringBenchmarks-report-github.md = benchmarks\results\Fractions.Benchmarks.ToStringBenchmarks-report-github.md

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ There a three types of constructors available:
 - `new Fraction (<numerator>, <denominator>, <reduce>)` using `BigInteger` for numerator and denominator + `bool` to indicate if the resulting fraction shall be normalized (reduced).
 
 > [!IMPORTANT]
-> When creating improper fractions (by specifying the parameter `reduce: false`), please be sure to refer to the [Working with non-normalized fractions](#working-with-non-normalized-fractions) and the [Equality operators](#equality-operators) section for more information about the (side) effects.
+> When creating improper fractions (by specifying the parameter `reduce: false`), please be sure to refer to the [Working with non-normalized fractions](#working-with-non-normalized-fractions) section for more information about the (side) effects.
 
 ### Static creation methods
 
@@ -317,7 +317,11 @@ $\frac{4}{4}/\frac{2}{1}=\frac{4}{8}$
 - `IComparable`,
 - `IComparable<Fraction>`
 
-Please note that `.Equals(Fraction)` will compare the **exact** values of numerator and denominator. That said:
+Please note that the default behavior of the `.Equals(Fraction)` method has changed with version 8.0.0. `Equals` now compares the calculated value from the $numerator/denominator$ ($Equals(\frac{1}{2}, \frac{2}{4}) = true$).
+
+If, on the other hand, you want to compare the numerator and denominator exactly (i.e. $Equals(\frac{1}{2}, \frac{2}{4}) = false$) then you have to use the new `FractionComparer.StrictEquality` comparer.
+
+That said:
 
 ```csharp
 var a = new Fraction(1, 2, normalize: true);
@@ -330,12 +334,14 @@ var result1 = a == a;
 // result2 is true
 var result2 = a == b;
 
-// result3 is false!
+// result3 is true
 var result3 = a == c;
-```
 
-> [!IMPORTANT]
-> The `Equals` method does not correspond to the mathematical equality test! You have to use `.IsEquivalentTo(Fraction)` if want to test non-normalized fractions for value-equality.
+// Special case:
+// same behavior as with double, see https://learn.microsoft.com/en-us/dotnet/api/system.double.op_equality#remarks
+// result4 is false 
+var result4 = Fraction.NaN == Fraction.NaN;
+```
 
 ## Under the hood
 

--- a/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
@@ -1,23 +1,59 @@
 ﻿using System.Numerics;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 namespace Fractions.Benchmarks;
 
 [MemoryDiagnoser]
-[ShortRunJob]
+[ShortRunJob(RuntimeMoniker.Net48)]
+[ShortRunJob(RuntimeMoniker.Net80)]
 public class ComparisonBenchmarks {
     public static IEnumerable<object[]> Operands() {
-        yield return [new Fraction(0, 1), new Fraction(1, 1)];
-        yield return [new Fraction(-1024, 1), new Fraction(-1, 1024)];
-        yield return [new Fraction(-45, 1), new Fraction(1, 6)];
-        yield return [new Fraction(BigInteger.Pow(-10, 37), 1), new Fraction(1, BigInteger.Pow(10 , 12))];
-        yield return [new Fraction(0.135m), new Fraction(0.076m)];
-        yield return [new Fraction(42, 66, false), new Fraction(36, 96, false)];  
-        yield return [new Fraction(144, 384, false), new Fraction(36, 96, false)]; // those are equivalent
-        yield return [Fraction.FromDouble(Math.PI), Fraction.FromDouble(Math.PI)];
-        yield return [Fraction.FromDoubleRounded(Math.PI), Fraction.FromDoubleRounded(Math.PI)];
-        yield return [Fraction.FromDouble(Math.PI), Fraction.FromDouble(Math.PI / 3)];
-        yield return [Fraction.FromDoubleRounded(Math.PI), Fraction.FromDoubleRounded(Math.PI / 3)];
+        // zero
+        yield return [Fraction.Zero, Fraction.One];
+        // basic integers (powers of 10)
+        yield return [
+            new Fraction(1000),
+            new Fraction(100)];
+        // prime integers 
+        yield return [
+            new Fraction(97),
+            new Fraction(89)];
+        // something per hour (non-reducible)
+        yield return [
+            new Fraction(77, 3600),
+            new Fraction(37, 3600)];
+        // {-1024} and {-1/1024}
+        yield return [
+            new Fraction(-1024, 1),
+            new Fraction(-1, 1024)];
+        // {-45} and {1/6}
+        yield return [
+            new Fraction(-45, 1),
+            new Fraction(1, 6)];
+        // {-10^37} and {1/10^12}
+        yield return [
+            new Fraction(BigInteger.Pow(-10, 37), 1),
+            new Fraction(1, BigInteger.Pow(10 , 12))];
+        // different denominators after reduction: {27/200} and {19/250}
+        yield return [
+            new Fraction(0.135m),
+            new Fraction(0.076m)];
+        yield return [
+            Fraction.FromDouble(Math.PI),
+            Fraction.FromDouble(Math.PI / 2)];
+        // {245850922/78256779} and {0}
+        yield return [
+            Fraction.FromDoubleRounded(Math.PI),
+            Fraction.Zero];
+        // {245850922/78256779} and {NaN}
+        yield return [
+            Fraction.FromDoubleRounded(Math.PI),
+            Fraction.NaN];
+        // {245850922/78256779} and {Infinity}
+        yield return [
+            Fraction.FromDoubleRounded(Math.PI),
+            Fraction.NegativeInfinity];
     }
 
     [Benchmark]
@@ -28,8 +64,20 @@ public class ComparisonBenchmarks {
 
     [Benchmark]
     [ArgumentsSource(nameof(Operands))]
+    public bool StrictEqualityEquals(Fraction a, Fraction b) {
+        return FractionComparer.StrictEquality.Equals(a, b);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
     public bool GetHashCode(Fraction a, Fraction b) {
         return a.GetHashCode() == b.GetHashCode();
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public bool StrictEqualityGetHashCode(Fraction a, Fraction b) {
+        return FractionComparer.StrictEquality.GetHashCode(a) == FractionComparer.StrictEquality.GetHashCode(b);
     }
 
     [Benchmark]

--- a/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/ComparisonBenchmarks.cs
@@ -28,12 +28,6 @@ public class ComparisonBenchmarks {
 
     [Benchmark]
     [ArgumentsSource(nameof(Operands))]
-    public bool IsEquivalentTo(Fraction a, Fraction b) {
-        return a.IsEquivalentTo(b);
-    }
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Operands))]
     public bool GetHashCode(Fraction a, Fraction b) {
         return a.GetHashCode() == b.GetHashCode();
     }

--- a/benchmarks/Fractions.Benchmarks/NonNormalizedComparisonBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/NonNormalizedComparisonBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿using System.Numerics;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Fractions.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob(RuntimeMoniker.Net48)]
+[ShortRunJob(RuntimeMoniker.Net80)]
+public class NonNormalizedComparisonBenchmarks {
+    public static IEnumerable<object[]> Operands() {
+        // zero
+        yield return [
+            new Fraction(BigInteger.Zero, BigInteger.One, false),
+            new Fraction(BigInteger.One, BigInteger.One, false)];
+        // basic integers (powers of 10)
+        yield return [
+            new Fraction(1000, BigInteger.One, false),
+            new Fraction(100, BigInteger.One, false)];
+        // prime integers 
+        yield return [
+            new Fraction(97, BigInteger.One, false),
+            new Fraction(89, BigInteger.One, false)];
+        // something per hour (non-reducible)
+        yield return [
+            new Fraction(77, 3600, false),
+            new Fraction(37, 3600, false)];
+        // {-1024} and {-1/1024}
+        yield return [
+            new Fraction(-1024, 1, false),
+            new Fraction(-1, 1024, false)];
+        // {-45} and {1/6}
+        yield return [
+            new Fraction(-45, 1, false),
+            new Fraction(1, 6, false)];
+        // {-10^37} and {1/10^12}
+        yield return [
+            new Fraction(BigInteger.Pow(-10, 37), 1, false),
+            new Fraction(1, BigInteger.Pow(10 , 12), false)];
+        // 0.135 and 0.076 as non-normalized fractions
+        yield return [
+            new Fraction(135, 1000, false),
+            new Fraction(76, 1000, false)];
+        // 0.135 and 0.076 after reduction: {27/200} and {19/250}
+        yield return [
+            new Fraction(27, 200, false),
+            new Fraction(19, 250, false)];
+        // {42/66} and {36/96}
+        yield return [
+            new Fraction(42, 66, false),
+            new Fraction(36, 96, false)];
+        // {42/-96} and {36/-96}
+        yield return [
+            new Fraction(42, -96, false),
+            new Fraction(36, -96, false)];
+        yield return [
+            Fraction.FromDouble(Math.PI, false),
+            Fraction.FromDouble(Math.PI / 2, false)];
+        // {245850922/78256779} and {0}
+        yield return [
+            Fraction.FromDoubleRounded(Math.PI, false),
+            Fraction.Zero];
+        // {245850922/78256779} and {NaN}
+        yield return [
+            Fraction.FromDoubleRounded(Math.PI, false),
+            Fraction.NaN];
+        // {245850922/78256779} and {Infinity}
+        yield return [
+            Fraction.FromDoubleRounded(Math.PI, false),
+            Fraction.NegativeInfinity];
+    }
+    
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public bool Equals(Fraction a, Fraction b) {
+        return a.Equals(b);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public bool GetHashCode(Fraction a, Fraction b) {
+        return a.GetHashCode() == b.GetHashCode();
+    }
+    
+    [Benchmark]
+    [ArgumentsSource(nameof(Operands))]
+    public int CompareTo(Fraction a, Fraction b) {
+        return a.CompareTo(b);
+    }
+}

--- a/benchmarks/results/Fractions.Benchmarks.BasicMathBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.BasicMathBenchmarks-report-github.md
@@ -1,134 +1,134 @@
 ```
 
-BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4291/22H2/2022Update)
+BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4412/22H2/2022Update)
 AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
-.NET SDK 8.0.204
-  [Host]                      : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  ShortRun-.NET 8.0           : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  ShortRun-.NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9232.0), X64 RyuJIT VectorSize=256
+.NET SDK 8.0.300
+  [Host]                      : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET 8.0           : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9241.0), X64 RyuJIT VectorSize=256
 
 IterationCount=3  LaunchCount=1  WarmupCount=3  
 
 ```
-| Method   | Job                         | Runtime            | a                    | b                    | Mean       | Error       | StdDev     | Gen0   | Allocated |
-|--------- |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|------------:|-----------:|-------:|----------:|
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)00000 [39]** | **1/1000000000000**      |  **92.693 ns** |   **5.2715 ns** |  **0.2889 ns** | **0.0057** |      **96 B** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  89.703 ns |   6.0574 ns |  0.3320 ns | 0.0057 |      96 B |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  86.496 ns |   2.5887 ns |  0.1419 ns | 0.0043 |      72 B |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  28.200 ns |   2.9600 ns |  0.1623 ns | 0.0029 |      48 B |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  68.281 ns |  12.2510 ns |  0.6715 ns | 0.0048 |      80 B |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 222.102 ns |  15.7739 ns |  0.8646 ns | 0.0229 |     144 B |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 238.411 ns |  87.6837 ns |  4.8062 ns | 0.0229 |     144 B |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 204.314 ns |  23.1492 ns |  1.2689 ns | 0.0293 |     185 B |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  88.423 ns |   8.9755 ns |  0.4920 ns | 0.0076 |      48 B |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 161.925 ns |  83.3118 ns |  4.5666 ns | 0.0076 |      48 B |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024**                | **-1/1024**              |  **40.210 ns** |   **3.6065 ns** |  **0.1977 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  43.594 ns |   5.6744 ns |  0.3110 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  26.938 ns |   0.7131 ns |  0.0391 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  13.538 ns |   2.7418 ns |  0.1503 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  37.752 ns |   3.7067 ns |  0.2032 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 121.532 ns |  20.6433 ns |  1.1315 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 141.683 ns |  18.4935 ns |  1.0137 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 112.588 ns |   8.1343 ns |  0.4459 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  52.685 ns |  23.0352 ns |  1.2626 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 127.874 ns |   5.8197 ns |  0.3190 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45**                  | **1/6**                  |  **40.938 ns** |   **0.9831 ns** |  **0.0539 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  41.072 ns |   6.5687 ns |  0.3601 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  22.443 ns |  20.3490 ns |  1.1154 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  12.946 ns |   1.3391 ns |  0.0734 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  37.571 ns |  12.5765 ns |  0.6894 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 127.019 ns |  51.1885 ns |  2.8058 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 130.844 ns |   9.6426 ns |  0.5285 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 105.833 ns |  11.8187 ns |  0.6478 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  54.079 ns |   0.4628 ns |  0.0254 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 120.674 ns |  16.3167 ns |  0.8944 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0**                    | **1**                    |  **14.745 ns** |   **0.3106 ns** |  **0.0170 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  16.124 ns |   1.2237 ns |  0.0671 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   7.368 ns |   3.4397 ns |  0.1885 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   8.532 ns |   4.1052 ns |  0.2250 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  11.397 ns |   3.8306 ns |  0.2100 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  27.819 ns |   2.4502 ns |  0.1343 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  42.011 ns |   1.8993 ns |  0.1041 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  28.552 ns |   0.9054 ns |  0.0496 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  27.610 ns |   2.1327 ns |  0.1169 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  30.212 ns |   0.6695 ns |  0.0367 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |  **53.297 ns** |   **4.2615 ns** |  **0.2336 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  45.298 ns |   4.2134 ns |  0.2309 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  34.548 ns |   3.1550 ns |  0.1729 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  36.701 ns |   2.7470 ns |  0.1506 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  37.659 ns |   5.0564 ns |  0.2772 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 133.968 ns |  12.4505 ns |  0.6825 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 156.782 ns |  97.0321 ns |  5.3187 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 116.681 ns |  69.0580 ns |  3.7853 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 146.239 ns |  10.6953 ns |  0.5862 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 132.572 ns |   1.5985 ns |  0.0876 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **71.228 ns** |  **53.5885 ns** |  **2.9374 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  70.457 ns |   3.9670 ns |  0.2174 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  34.082 ns |   0.4353 ns |  0.0239 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  39.308 ns |   5.9471 ns |  0.3260 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  64.239 ns |   5.0953 ns |  0.2793 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 213.763 ns |  39.1192 ns |  2.1443 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 261.882 ns |  26.1444 ns |  1.4331 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 108.920 ns |   4.2043 ns |  0.2305 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 157.019 ns | 114.1595 ns |  6.2575 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 247.183 ns |  52.9146 ns |  2.9004 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **88427(...)21312 [31]** | **134.620 ns** |  **17.9387 ns** |  **0.9833 ns** | **0.0057** |      **96 B** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 147.726 ns |  11.1366 ns |  0.6104 ns | 0.0057 |      96 B |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 224.225 ns | 166.3372 ns |  9.1175 ns | 0.0048 |      80 B |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 120.195 ns |  10.7106 ns |  0.5871 ns | 0.0072 |     120 B |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 111.675 ns |   4.0359 ns |  0.2212 ns | 0.0057 |      96 B |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 250.862 ns |  17.3291 ns |  0.9499 ns | 0.0229 |     144 B |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 287.512 ns | 549.7979 ns | 30.1363 ns | 0.0215 |     136 B |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 171.510 ns |  10.3390 ns |  0.5667 ns | 0.0126 |      80 B |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 303.090 ns |  53.0319 ns |  2.9069 ns | 0.0443 |     281 B |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 338.322 ns |  77.2623 ns |  4.2350 ns | 0.0267 |     168 B |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |  **15.095 ns** |   **0.4484 ns** |  **0.0246 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  16.369 ns |   0.3567 ns |  0.0196 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   8.328 ns |   0.2111 ns |  0.0116 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   6.286 ns |   1.0267 ns |  0.0563 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  11.192 ns |   3.5882 ns |  0.1967 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  27.907 ns |   4.7094 ns |  0.2581 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  42.646 ns |   2.5337 ns |  0.1389 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  31.047 ns |   1.0029 ns |  0.0550 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  25.025 ns |   0.3997 ns |  0.0219 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  30.251 ns |   2.9873 ns |  0.1637 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |  **15.181 ns** |   **0.6831 ns** |  **0.0374 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  17.039 ns |   1.1273 ns |  0.0618 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   9.041 ns |   0.7865 ns |  0.0431 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   5.981 ns |   0.4068 ns |  0.0223 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  11.201 ns |   1.0678 ns |  0.0585 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  30.699 ns |   1.4576 ns |  0.0799 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  45.482 ns |   5.4505 ns |  0.2988 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  32.045 ns |   0.5326 ns |  0.0292 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  24.243 ns |   2.5626 ns |  0.1405 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  29.616 ns |   3.0109 ns |  0.1650 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |  **15.232 ns** |   **0.9014 ns** |  **0.0494 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  15.970 ns |   0.0814 ns |  0.0045 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.949 ns |   5.9677 ns |  0.3271 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   8.168 ns |   0.3481 ns |  0.0191 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  11.054 ns |   0.7325 ns |  0.0402 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  27.404 ns |   0.6781 ns |  0.0372 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  41.408 ns |   1.4550 ns |  0.0798 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  27.969 ns |   0.6638 ns |  0.0364 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  31.494 ns |   2.6354 ns |  0.1445 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  30.078 ns |   1.2759 ns |  0.0699 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97**                   | **89**                   |  **28.330 ns** |   **2.4227 ns** |  **0.1328 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  28.693 ns |   1.1787 ns |  0.0646 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  13.719 ns |   1.2334 ns |  0.0676 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  12.907 ns |   0.1142 ns |  0.0063 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  21.587 ns |  21.5347 ns |  1.1804 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  69.308 ns |   8.9040 ns |  0.4881 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  79.960 ns |   3.8613 ns |  0.2117 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  51.973 ns |   2.8364 ns |  0.1555 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  71.987 ns |   1.0810 ns |  0.0593 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  64.315 ns |   5.6489 ns |  0.3096 ns |      - |         - |
-| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000**                 | **100**                  |  **28.376 ns** |   **1.7016 ns** |  **0.0933 ns** |      **-** |         **-** |
-| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  30.101 ns |   1.6135 ns |  0.0884 ns |      - |         - |
-| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  13.082 ns |   0.7161 ns |  0.0393 ns |      - |         - |
-| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  21.157 ns |   0.6629 ns |  0.0363 ns |      - |         - |
-| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  20.407 ns |   1.7696 ns |  0.0970 ns |      - |         - |
-| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  65.184 ns |   7.7377 ns |  0.4241 ns |      - |         - |
-| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  80.622 ns |   0.9851 ns |  0.0540 ns |      - |         - |
-| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  51.854 ns |   2.6134 ns |  0.1432 ns |      - |         - |
-| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  | 110.653 ns |   0.5593 ns |  0.0307 ns |      - |         - |
-| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  52.643 ns |   1.6214 ns |  0.0889 ns |      - |         - |
+| Method   | Job                         | Runtime            | a                    | b                    | Mean       | Error      | StdDev    | Gen0   | Allocated |
+|--------- |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|-----------:|----------:|-------:|----------:|
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)00000 [39]** | **1/1000000000000**      |  **95.199 ns** |  **9.1322 ns** | **0.5006 ns** | **0.0057** |      **96 B** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  89.889 ns |  3.1398 ns | 0.1721 ns | 0.0057 |      96 B |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  87.165 ns |  4.4154 ns | 0.2420 ns | 0.0043 |      72 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  28.500 ns |  1.9854 ns | 0.1088 ns | 0.0029 |      48 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  66.942 ns |  7.0499 ns | 0.3864 ns | 0.0048 |      80 B |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 219.165 ns |  4.2306 ns | 0.2319 ns | 0.0229 |     144 B |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 225.834 ns |  9.9567 ns | 0.5458 ns | 0.0229 |     144 B |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 209.665 ns | 11.5784 ns | 0.6346 ns | 0.0293 |     185 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  96.000 ns |  5.8479 ns | 0.3205 ns | 0.0076 |      48 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      | 158.681 ns |  5.7642 ns | 0.3160 ns | 0.0076 |      48 B |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024**                | **-1/1024**              |  **40.074 ns** |  **2.5166 ns** | **0.1379 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  44.031 ns |  2.7964 ns | 0.1533 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  26.751 ns |  0.4453 ns | 0.0244 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  14.123 ns |  0.1508 ns | 0.0083 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  37.029 ns |  0.5318 ns | 0.0291 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 124.364 ns |  4.3495 ns | 0.2384 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 142.203 ns | 11.2304 ns | 0.6156 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 122.981 ns | 18.1903 ns | 0.9971 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  62.124 ns |  3.5514 ns | 0.1947 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              | 128.688 ns | 13.3258 ns | 0.7304 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45**                  | **1/6**                  |  **42.399 ns** |  **7.3750 ns** | **0.4042 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  41.244 ns |  4.2129 ns | 0.2309 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  26.227 ns |  0.8679 ns | 0.0476 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  13.827 ns |  1.4593 ns | 0.0800 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  36.632 ns |  1.1558 ns | 0.0634 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 121.335 ns | 10.7987 ns | 0.5919 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 133.819 ns |  3.8892 ns | 0.2132 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 113.557 ns |  2.4518 ns | 0.1344 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  60.616 ns |  6.6020 ns | 0.3619 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  | 121.384 ns |  7.4361 ns | 0.4076 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0**                    | **1**                    |  **14.954 ns** |  **0.2827 ns** | **0.0155 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  15.938 ns |  0.0508 ns | 0.0028 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   7.588 ns |  0.9740 ns | 0.0534 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   8.994 ns |  0.7697 ns | 0.0422 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  11.156 ns |  0.4995 ns | 0.0274 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  27.795 ns |  3.0433 ns | 0.1668 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  42.715 ns |  0.3125 ns | 0.0171 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  28.292 ns |  0.6269 ns | 0.0344 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  28.716 ns |  0.7893 ns | 0.0433 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  30.156 ns |  0.3009 ns | 0.0165 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |  **53.520 ns** |  **1.5465 ns** | **0.0848 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  48.482 ns | 61.9604 ns | 3.3963 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  34.323 ns |  2.0545 ns | 0.1126 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  36.515 ns |  2.3743 ns | 0.1301 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  36.796 ns |  4.2824 ns | 0.2347 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 135.027 ns |  3.6677 ns | 0.2010 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 155.732 ns | 11.5421 ns | 0.6327 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 119.029 ns | 19.5190 ns | 1.0699 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 141.668 ns |  7.5039 ns | 0.4113 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 132.196 ns |  5.1143 ns | 0.2803 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **70.012 ns** |  **6.4705 ns** | **0.3547 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  70.075 ns |  7.6168 ns | 0.4175 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  34.973 ns |  1.8245 ns | 0.1000 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  40.637 ns |  0.4461 ns | 0.0245 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  64.027 ns |  1.6898 ns | 0.0926 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 218.939 ns | 17.5040 ns | 0.9595 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 248.387 ns | 13.6223 ns | 0.7467 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 110.852 ns | 19.2098 ns | 1.0530 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 151.401 ns | 51.5804 ns | 2.8273 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 248.500 ns | 16.5244 ns | 0.9058 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **88427(...)21312 [31]** | **134.973 ns** | **27.0936 ns** | **1.4851 ns** | **0.0057** |      **96 B** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 147.855 ns | 17.9093 ns | 0.9817 ns | 0.0057 |      96 B |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 221.528 ns | 75.7761 ns | 4.1535 ns | 0.0048 |      80 B |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 114.605 ns | 10.6555 ns | 0.5841 ns | 0.0072 |     120 B |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] | 109.353 ns |  1.4763 ns | 0.0809 ns | 0.0057 |      96 B |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 250.897 ns | 13.9097 ns | 0.7624 ns | 0.0229 |     144 B |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 269.032 ns | 10.5937 ns | 0.5807 ns | 0.0215 |     136 B |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 172.323 ns |  2.8651 ns | 0.1570 ns | 0.0126 |      80 B |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 298.506 ns | 21.2627 ns | 1.1655 ns | 0.0443 |     281 B |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 344.260 ns | 43.7628 ns | 2.3988 ns | 0.0267 |     168 B |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |  **15.233 ns** |  **0.1239 ns** | **0.0068 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  16.343 ns |  0.3351 ns | 0.0184 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   8.521 ns |  0.0935 ns | 0.0051 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   6.234 ns |  0.0147 ns | 0.0008 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  11.320 ns |  0.1729 ns | 0.0095 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  27.509 ns |  0.3631 ns | 0.0199 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  42.014 ns |  0.2468 ns | 0.0135 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  30.751 ns |  1.7318 ns | 0.0949 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  25.247 ns |  0.2547 ns | 0.0140 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  30.223 ns |  0.4986 ns | 0.0273 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |  **16.187 ns** | **33.2476 ns** | **1.8224 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  17.512 ns |  2.8435 ns | 0.1559 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   8.945 ns |  5.5277 ns | 0.3030 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   6.113 ns |  0.6705 ns | 0.0368 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  11.114 ns |  1.4386 ns | 0.0789 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  30.420 ns |  1.7443 ns | 0.0956 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  45.607 ns |  3.7039 ns | 0.2030 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  30.736 ns |  1.1531 ns | 0.0632 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  25.565 ns |  0.6144 ns | 0.0337 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  29.861 ns |  0.1494 ns | 0.0082 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |  **14.751 ns** |  **0.3392 ns** | **0.0186 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  16.011 ns |  0.1908 ns | 0.0105 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.922 ns |  0.6052 ns | 0.0332 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   8.698 ns |  0.4816 ns | 0.0264 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  11.188 ns |  0.5776 ns | 0.0317 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  27.680 ns |  0.6313 ns | 0.0346 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  42.630 ns |  0.0651 ns | 0.0036 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  28.494 ns |  0.3546 ns | 0.0194 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  32.492 ns |  5.2799 ns | 0.2894 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  30.265 ns |  0.4405 ns | 0.0241 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97**                   | **89**                   |  **28.071 ns** |  **0.8983 ns** | **0.0492 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  29.516 ns |  2.0714 ns | 0.1135 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  13.216 ns |  2.5842 ns | 0.1416 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  15.287 ns |  0.4768 ns | 0.0261 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  21.077 ns |  1.0152 ns | 0.0556 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  67.698 ns |  1.6627 ns | 0.0911 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  80.498 ns |  1.3702 ns | 0.0751 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  61.007 ns |  2.3687 ns | 0.1298 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  81.591 ns |  0.2659 ns | 0.0146 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  63.657 ns |  2.8617 ns | 0.1569 ns |      - |         - |
+| **Add**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000**                 | **100**                  |  **28.236 ns** |  **1.6100 ns** | **0.0883 ns** |      **-** |         **-** |
+| Subtract | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  29.482 ns |  2.0048 ns | 0.1099 ns |      - |         - |
+| Multiply | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  13.705 ns |  4.3437 ns | 0.2381 ns |      - |         - |
+| Divide   | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  22.385 ns |  0.7068 ns | 0.0387 ns |      - |         - |
+| Mod      | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  20.862 ns |  1.4756 ns | 0.0809 ns |      - |         - |
+| Add      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  62.891 ns |  3.0970 ns | 0.1698 ns |      - |         - |
+| Subtract | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  80.103 ns |  1.6037 ns | 0.0879 ns |      - |         - |
+| Multiply | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  59.881 ns |  2.5696 ns | 0.1408 ns |      - |         - |
+| Divide   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  | 125.236 ns | 43.5330 ns | 2.3862 ns |      - |         - |
+| Mod      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  52.710 ns |  2.5086 ns | 0.1375 ns |      - |         - |

--- a/benchmarks/results/Fractions.Benchmarks.ComparisonBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.ComparisonBenchmarks-report-github.md
@@ -1,58 +1,134 @@
 ```
 
-BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4291/22H2/2022Update)
+BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4412/22H2/2022Update)
 AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
-.NET SDK 8.0.204
-  [Host]   : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  ShortRun : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+.NET SDK 8.0.300
+  [Host]                      : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET 8.0           : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9241.0), X64 RyuJIT VectorSize=256
 
-Job=ShortRun  IterationCount=3  LaunchCount=1  
-WarmupCount=3  
+IterationCount=3  LaunchCount=1  WarmupCount=3  
 
 ```
-| Method         | a                    | b                    | Mean      | Error     | StdDev    | Gen0   | Allocated |
-|--------------- |--------------------- |--------------------- |----------:|----------:|----------:|-------:|----------:|
-| **Equals**         | **-1000(...)00000 [39]** | **1/1000000000000**      |  **2.712 ns** | **0.2608 ns** | **0.0143 ns** |      **-** |         **-** |
-| IsEquivalentTo | -1000(...)00000 [39] | 1/1000000000000      |  7.903 ns | 0.1666 ns | 0.0091 ns |      - |         - |
-| GetHashCode    | -1000(...)00000 [39] | 1/1000000000000      | 24.366 ns | 4.4538 ns | 0.2441 ns |      - |         - |
-| CompareTo      | -1000(...)00000 [39] | 1/1000000000000      | 28.302 ns | 3.1271 ns | 0.1714 ns | 0.0029 |      48 B |
-| **Equals**         | **-1024**                | **-1/1024**              |  **2.608 ns** | **0.1387 ns** | **0.0076 ns** |      **-** |         **-** |
-| IsEquivalentTo | -1024                | -1/1024              |  7.591 ns | 1.2081 ns | 0.0662 ns |      - |         - |
-| GetHashCode    | -1024                | -1/1024              |  7.883 ns | 0.3676 ns | 0.0202 ns |      - |         - |
-| CompareTo      | -1024                | -1/1024              | 15.414 ns | 1.0311 ns | 0.0565 ns |      - |         - |
-| **Equals**         | **-45**                  | **1/6**                  |  **2.519 ns** | **0.2855 ns** | **0.0156 ns** |      **-** |         **-** |
-| IsEquivalentTo | -45                  | 1/6                  |  7.946 ns | 1.0044 ns | 0.0551 ns |      - |         - |
-| GetHashCode    | -45                  | 1/6                  |  7.895 ns | 0.7097 ns | 0.0389 ns |      - |         - |
-| CompareTo      | -45                  | 1/6                  | 15.046 ns | 0.5091 ns | 0.0279 ns |      - |         - |
-| **Equals**         | **0**                    | **1**                    |  **2.685 ns** | **0.2639 ns** | **0.0145 ns** |      **-** |         **-** |
-| IsEquivalentTo | 0                    | 1                    |  7.498 ns | 0.8069 ns | 0.0442 ns |      - |         - |
-| GetHashCode    | 0                    | 1                    |  7.612 ns | 1.1553 ns | 0.0633 ns |      - |         - |
-| CompareTo      | 0                    | 1                    |  4.270 ns | 0.5845 ns | 0.0320 ns |      - |         - |
-| **Equals**         | **27/200**               | **19/250**               |  **2.553 ns** | **0.2120 ns** | **0.0116 ns** |      **-** |         **-** |
-| IsEquivalentTo | 27/200               | 19/250               |  7.901 ns | 0.3816 ns | 0.0209 ns |      - |         - |
-| GetHashCode    | 27/200               | 19/250               |  7.941 ns | 1.2119 ns | 0.0664 ns |      - |         - |
-| CompareTo      | 27/200               | 19/250               | 14.879 ns | 0.5512 ns | 0.0302 ns |      - |         - |
-| **Equals**         | **144/384**              | **36/96**                |  **2.536 ns** | **0.3394 ns** | **0.0186 ns** |      **-** |         **-** |
-| IsEquivalentTo | 144/384              | 36/96                | 43.542 ns | 2.3287 ns | 0.1276 ns |      - |         - |
-| GetHashCode    | 144/384              | 36/96                |  7.843 ns | 0.0568 ns | 0.0031 ns |      - |         - |
-| CompareTo      | 144/384              | 36/96                | 15.462 ns | 0.2606 ns | 0.0143 ns |      - |         - |
-| **Equals**         | **42/66**                | **36/96**                |  **2.627 ns** | **0.1770 ns** | **0.0097 ns** |      **-** |         **-** |
-| IsEquivalentTo | 42/66                | 36/96                | 46.281 ns | 1.6575 ns | 0.0909 ns |      - |         - |
-| GetHashCode    | 42/66                | 36/96                |  7.930 ns | 0.4074 ns | 0.0223 ns |      - |         - |
-| CompareTo      | 42/66                | 36/96                | 15.000 ns | 0.6517 ns | 0.0357 ns |      - |         - |
-| **Equals**         | **88427(...)10656 [31]** | **47161(...)70496 [33]** |  **3.020 ns** | **1.0410 ns** | **0.0571 ns** |      **-** |         **-** |
-| IsEquivalentTo | 88427(...)10656 [31] | 47161(...)70496 [33] |  7.560 ns | 0.3766 ns | 0.0206 ns |      - |         - |
-| GetHashCode    | 88427(...)10656 [31] | 47161(...)70496 [33] | 33.403 ns | 3.9777 ns | 0.2180 ns |      - |         - |
-| CompareTo      | 88427(...)10656 [31] | 47161(...)70496 [33] | 42.118 ns | 4.5126 ns | 0.2474 ns | 0.0048 |      80 B |
-| **Equals**         | **88427(...)10656 [31]** | **88427(...)10656 [31]** |  **6.804 ns** | **0.6788 ns** | **0.0372 ns** |      **-** |         **-** |
-| IsEquivalentTo | 88427(...)10656 [31] | 88427(...)10656 [31] | 10.106 ns | 0.8848 ns | 0.0485 ns |      - |         - |
-| GetHashCode    | 88427(...)10656 [31] | 88427(...)10656 [31] | 32.880 ns | 1.4371 ns | 0.0788 ns |      - |         - |
-| CompareTo      | 88427(...)10656 [31] | 88427(...)10656 [31] |  7.046 ns | 0.1846 ns | 0.0101 ns |      - |         - |
-| **Equals**         | **245850922/78256779**   | **26714619/25510582**    |  **2.626 ns** | **0.1195 ns** | **0.0066 ns** |      **-** |         **-** |
-| IsEquivalentTo | 245850922/78256779   | 26714619/25510582    |  7.616 ns | 0.3143 ns | 0.0172 ns |      - |         - |
-| GetHashCode    | 245850922/78256779   | 26714619/25510582    |  7.884 ns | 0.7592 ns | 0.0416 ns |      - |         - |
-| CompareTo      | 245850922/78256779   | 26714619/25510582    | 21.017 ns | 2.0007 ns | 0.1097 ns | 0.0038 |      64 B |
-| **Equals**         | **245850922/78256779**   | **245850922/78256779**   |  **3.495 ns** | **0.4878 ns** | **0.0267 ns** |      **-** |         **-** |
-| IsEquivalentTo | 245850922/78256779   | 245850922/78256779   |  7.542 ns | 1.2834 ns | 0.0703 ns |      - |         - |
-| GetHashCode    | 245850922/78256779   | 245850922/78256779   |  8.022 ns | 0.8855 ns | 0.0485 ns |      - |         - |
-| CompareTo      | 245850922/78256779   | 245850922/78256779   |  4.899 ns | 0.5226 ns | 0.0286 ns |      - |         - |
+| Method                    | Job                         | Runtime            | a                    | b                    | Mean       | Error      | StdDev    | Gen0   | Allocated |
+|-------------------------- |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|-----------:|----------:|-------:|----------:|
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)00000 [39]** | **1/1000000000000**      |  **25.694 ns** |  **3.1141 ns** | **0.1707 ns** | **0.0029** |      **48 B** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |   3.929 ns |  0.4083 ns | 0.0224 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  22.699 ns |  0.5989 ns | 0.0328 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  21.893 ns |  1.9434 ns | 0.1065 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  24.168 ns |  3.2012 ns | 0.1755 ns | 0.0029 |      48 B |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  71.137 ns |  3.9653 ns | 0.2174 ns | 0.0076 |      48 B |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  10.086 ns |  1.0774 ns | 0.0591 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  38.444 ns |  6.1483 ns | 0.3370 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  19.505 ns |  0.2179 ns | 0.0119 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  79.842 ns |  5.0205 ns | 0.2752 ns | 0.0076 |      48 B |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024**                | **-1/1024**              |   **9.759 ns** |  **1.4416 ns** | **0.0790 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   4.090 ns |  0.1207 ns | 0.0066 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  10.762 ns |  2.4600 ns | 0.1348 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   7.918 ns |  0.1811 ns | 0.0099 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   9.552 ns |  0.1815 ns | 0.0099 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  35.710 ns |  3.1209 ns | 0.1711 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |   9.806 ns |  0.2432 ns | 0.0133 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  37.871 ns |  4.1972 ns | 0.2301 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  18.168 ns |  1.1915 ns | 0.0653 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  43.511 ns |  2.1550 ns | 0.1181 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45**                  | **1/6**                  |  **10.555 ns** |  **2.0678 ns** | **0.1133 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   4.137 ns |  0.0641 ns | 0.0035 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  10.712 ns |  6.7499 ns | 0.3700 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   7.534 ns |  0.8596 ns | 0.0471 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   9.011 ns |  0.7160 ns | 0.0392 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  35.576 ns |  2.1697 ns | 0.1189 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |   8.647 ns |  2.0367 ns | 0.1116 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  29.906 ns |  0.8514 ns | 0.0467 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  18.092 ns |  0.6874 ns | 0.0377 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  43.745 ns |  0.2108 ns | 0.0116 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0**                    | **1**                    |   **4.505 ns** |  **0.0578 ns** | **0.0032 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   4.089 ns |  0.5526 ns | 0.0303 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  10.724 ns |  0.2874 ns | 0.0158 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   7.715 ns |  0.1287 ns | 0.0071 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   4.794 ns |  0.7229 ns | 0.0396 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  15.918 ns |  1.6840 ns | 0.0923 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  10.078 ns |  0.1845 ns | 0.0101 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  34.931 ns |  3.1652 ns | 0.1735 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  18.272 ns |  1.2848 ns | 0.0704 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  30.011 ns |  0.3189 ns | 0.0175 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |   **4.698 ns** |  **0.2239 ns** | **0.0123 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.074 ns |  0.1591 ns | 0.0087 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  11.286 ns |  1.2151 ns | 0.0666 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   7.951 ns |  0.0308 ns | 0.0017 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.982 ns |  0.5159 ns | 0.0283 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  20.458 ns |  0.6828 ns | 0.0374 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |   8.574 ns |  1.4775 ns | 0.0810 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  35.035 ns |  0.6656 ns | 0.0365 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  18.260 ns |  0.3631 ns | 0.0199 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  30.006 ns |  0.1576 ns | 0.0086 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **15.838 ns** |  **2.1451 ns** | **0.1176 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |   3.912 ns |  0.1841 ns | 0.0101 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  10.546 ns |  0.3580 ns | 0.0196 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |   7.739 ns |  0.3747 ns | 0.0205 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  15.052 ns |  0.1334 ns | 0.0073 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  55.315 ns |  2.2459 ns | 0.1231 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  10.481 ns |  0.3474 ns | 0.0190 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  35.198 ns |  0.4679 ns | 0.0256 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  18.140 ns |  0.4887 ns | 0.0268 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  61.040 ns |  6.9295 ns | 0.3798 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **88427(...)21312 [31]** |  **48.256 ns** | **24.2880 ns** | **1.3313 ns** | **0.0048** |      **80 B** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |   5.903 ns |  0.2100 ns | 0.0115 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  34.035 ns |  1.5763 ns | 0.0864 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  32.185 ns |  0.2096 ns | 0.0115 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  41.946 ns |  0.1573 ns | 0.0086 ns | 0.0048 |      80 B |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 112.958 ns |  6.7483 ns | 0.3699 ns | 0.0126 |      80 B |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  21.821 ns |  1.4357 ns | 0.0787 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  35.715 ns |  1.2400 ns | 0.0680 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  23.877 ns |  0.2954 ns | 0.0162 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 130.780 ns |  2.3437 ns | 0.1285 ns | 0.0126 |      80 B |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **3.955 ns** |  **0.1801 ns** | **0.0099 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   3.950 ns |  0.0645 ns | 0.0035 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  10.861 ns |  1.0164 ns | 0.0557 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   7.734 ns |  0.0836 ns | 0.0046 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   2.447 ns |  0.1288 ns | 0.0071 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  19.590 ns |  1.1834 ns | 0.0649 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  10.026 ns |  0.3050 ns | 0.0167 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  34.834 ns |  0.0635 ns | 0.0035 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  17.971 ns |  0.4923 ns | 0.0270 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  21.949 ns |  0.4685 ns | 0.0257 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **3.965 ns** |  **0.1989 ns** | **0.0109 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   4.097 ns |  0.1796 ns | 0.0098 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  10.674 ns |  0.1941 ns | 0.0106 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   7.967 ns |  0.1346 ns | 0.0074 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   4.830 ns |  0.0396 ns | 0.0022 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  19.748 ns |  0.5883 ns | 0.0322 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |   8.607 ns |  0.7613 ns | 0.0417 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  35.056 ns |  1.1581 ns | 0.0635 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  18.157 ns |  1.1907 ns | 0.0653 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  29.172 ns |  0.5701 ns | 0.0312 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **3.769 ns** |  **0.2107 ns** | **0.0115 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   3.927 ns |  0.0997 ns | 0.0055 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  10.706 ns |  0.4235 ns | 0.0232 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.594 ns |  0.2313 ns | 0.0127 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   4.874 ns |  0.3784 ns | 0.0207 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  19.994 ns |  1.7029 ns | 0.0933 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |   4.621 ns |  0.9459 ns | 0.0518 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  35.095 ns |  0.9536 ns | 0.0523 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  18.048 ns |  0.0395 ns | 0.0022 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  35.466 ns |  0.3885 ns | 0.0213 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97**                   | **89**                   |   **4.581 ns** |  **4.0918 ns** | **0.2243 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   3.918 ns |  0.5192 ns | 0.0285 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  11.270 ns |  1.3143 ns | 0.0720 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   7.895 ns |  0.7547 ns | 0.0414 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   4.877 ns |  0.4726 ns | 0.0259 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  15.735 ns |  0.5150 ns | 0.0282 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |   8.454 ns |  1.6834 ns | 0.0923 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  34.801 ns |  3.5997 ns | 0.1973 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  17.918 ns |  1.2509 ns | 0.0686 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  29.874 ns |  3.0591 ns | 0.1677 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000**                 | **100**                  |   **4.408 ns** |  **0.1518 ns** | **0.0083 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   4.104 ns |  0.3148 ns | 0.0173 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  10.530 ns |  0.4111 ns | 0.0225 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   7.554 ns |  0.1007 ns | 0.0055 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   5.029 ns |  0.2079 ns | 0.0114 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  20.509 ns |  0.5477 ns | 0.0300 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |   4.447 ns |  0.2894 ns | 0.0159 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  34.918 ns |  1.0153 ns | 0.0557 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  12.493 ns |  0.6296 ns | 0.0345 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  29.721 ns |  0.2429 ns | 0.0133 ns |      - |         - |

--- a/benchmarks/results/Fractions.Benchmarks.ComparisonBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.ComparisonBenchmarks-report-github.md
@@ -10,125 +10,125 @@ AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
 IterationCount=3  LaunchCount=1  WarmupCount=3  
 
 ```
-| Method                    | Job                         | Runtime            | a                    | b                    | Mean       | Error      | StdDev    | Gen0   | Allocated |
-|-------------------------- |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|-----------:|----------:|-------:|----------:|
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)00000 [39]** | **1/1000000000000**      |  **25.694 ns** |  **3.1141 ns** | **0.1707 ns** | **0.0029** |      **48 B** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |   3.929 ns |  0.4083 ns | 0.0224 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  22.699 ns |  0.5989 ns | 0.0328 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  21.893 ns |  1.9434 ns | 0.1065 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  24.168 ns |  3.2012 ns | 0.1755 ns | 0.0029 |      48 B |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  71.137 ns |  3.9653 ns | 0.2174 ns | 0.0076 |      48 B |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  10.086 ns |  1.0774 ns | 0.0591 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  38.444 ns |  6.1483 ns | 0.3370 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  19.505 ns |  0.2179 ns | 0.0119 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  79.842 ns |  5.0205 ns | 0.2752 ns | 0.0076 |      48 B |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024**                | **-1/1024**              |   **9.759 ns** |  **1.4416 ns** | **0.0790 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   4.090 ns |  0.1207 ns | 0.0066 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  10.762 ns |  2.4600 ns | 0.1348 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   7.918 ns |  0.1811 ns | 0.0099 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   9.552 ns |  0.1815 ns | 0.0099 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  35.710 ns |  3.1209 ns | 0.1711 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |   9.806 ns |  0.2432 ns | 0.0133 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  37.871 ns |  4.1972 ns | 0.2301 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  18.168 ns |  1.1915 ns | 0.0653 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  43.511 ns |  2.1550 ns | 0.1181 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45**                  | **1/6**                  |  **10.555 ns** |  **2.0678 ns** | **0.1133 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   4.137 ns |  0.0641 ns | 0.0035 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  10.712 ns |  6.7499 ns | 0.3700 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   7.534 ns |  0.8596 ns | 0.0471 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   9.011 ns |  0.7160 ns | 0.0392 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  35.576 ns |  2.1697 ns | 0.1189 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |   8.647 ns |  2.0367 ns | 0.1116 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  29.906 ns |  0.8514 ns | 0.0467 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  18.092 ns |  0.6874 ns | 0.0377 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  43.745 ns |  0.2108 ns | 0.0116 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0**                    | **1**                    |   **4.505 ns** |  **0.0578 ns** | **0.0032 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   4.089 ns |  0.5526 ns | 0.0303 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  10.724 ns |  0.2874 ns | 0.0158 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   7.715 ns |  0.1287 ns | 0.0071 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   4.794 ns |  0.7229 ns | 0.0396 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  15.918 ns |  1.6840 ns | 0.0923 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  10.078 ns |  0.1845 ns | 0.0101 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  34.931 ns |  3.1652 ns | 0.1735 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  18.272 ns |  1.2848 ns | 0.0704 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  30.011 ns |  0.3189 ns | 0.0175 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |   **4.698 ns** |  **0.2239 ns** | **0.0123 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.074 ns |  0.1591 ns | 0.0087 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  11.286 ns |  1.2151 ns | 0.0666 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   7.951 ns |  0.0308 ns | 0.0017 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.982 ns |  0.5159 ns | 0.0283 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  20.458 ns |  0.6828 ns | 0.0374 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |   8.574 ns |  1.4775 ns | 0.0810 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  35.035 ns |  0.6656 ns | 0.0365 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  18.260 ns |  0.3631 ns | 0.0199 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  30.006 ns |  0.1576 ns | 0.0086 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **15.838 ns** |  **2.1451 ns** | **0.1176 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |   3.912 ns |  0.1841 ns | 0.0101 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  10.546 ns |  0.3580 ns | 0.0196 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |   7.739 ns |  0.3747 ns | 0.0205 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  15.052 ns |  0.1334 ns | 0.0073 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  55.315 ns |  2.2459 ns | 0.1231 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  10.481 ns |  0.3474 ns | 0.0190 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  35.198 ns |  0.4679 ns | 0.0256 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  18.140 ns |  0.4887 ns | 0.0268 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  61.040 ns |  6.9295 ns | 0.3798 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **88427(...)21312 [31]** |  **48.256 ns** | **24.2880 ns** | **1.3313 ns** | **0.0048** |      **80 B** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |   5.903 ns |  0.2100 ns | 0.0115 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  34.035 ns |  1.5763 ns | 0.0864 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  32.185 ns |  0.2096 ns | 0.0115 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  41.946 ns |  0.1573 ns | 0.0086 ns | 0.0048 |      80 B |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 112.958 ns |  6.7483 ns | 0.3699 ns | 0.0126 |      80 B |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  21.821 ns |  1.4357 ns | 0.0787 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  35.715 ns |  1.2400 ns | 0.0680 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  23.877 ns |  0.2954 ns | 0.0162 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 130.780 ns |  2.3437 ns | 0.1285 ns | 0.0126 |      80 B |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **3.955 ns** |  **0.1801 ns** | **0.0099 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   3.950 ns |  0.0645 ns | 0.0035 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  10.861 ns |  1.0164 ns | 0.0557 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   7.734 ns |  0.0836 ns | 0.0046 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   2.447 ns |  0.1288 ns | 0.0071 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  19.590 ns |  1.1834 ns | 0.0649 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  10.026 ns |  0.3050 ns | 0.0167 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  34.834 ns |  0.0635 ns | 0.0035 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  17.971 ns |  0.4923 ns | 0.0270 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  21.949 ns |  0.4685 ns | 0.0257 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **3.965 ns** |  **0.1989 ns** | **0.0109 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   4.097 ns |  0.1796 ns | 0.0098 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  10.674 ns |  0.1941 ns | 0.0106 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   7.967 ns |  0.1346 ns | 0.0074 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   4.830 ns |  0.0396 ns | 0.0022 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  19.748 ns |  0.5883 ns | 0.0322 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |   8.607 ns |  0.7613 ns | 0.0417 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  35.056 ns |  1.1581 ns | 0.0635 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  18.157 ns |  1.1907 ns | 0.0653 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  29.172 ns |  0.5701 ns | 0.0312 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **3.769 ns** |  **0.2107 ns** | **0.0115 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   3.927 ns |  0.0997 ns | 0.0055 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  10.706 ns |  0.4235 ns | 0.0232 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.594 ns |  0.2313 ns | 0.0127 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   4.874 ns |  0.3784 ns | 0.0207 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  19.994 ns |  1.7029 ns | 0.0933 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |   4.621 ns |  0.9459 ns | 0.0518 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  35.095 ns |  0.9536 ns | 0.0523 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  18.048 ns |  0.0395 ns | 0.0022 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  35.466 ns |  0.3885 ns | 0.0213 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97**                   | **89**                   |   **4.581 ns** |  **4.0918 ns** | **0.2243 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   3.918 ns |  0.5192 ns | 0.0285 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  11.270 ns |  1.3143 ns | 0.0720 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   7.895 ns |  0.7547 ns | 0.0414 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   4.877 ns |  0.4726 ns | 0.0259 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  15.735 ns |  0.5150 ns | 0.0282 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |   8.454 ns |  1.6834 ns | 0.0923 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  34.801 ns |  3.5997 ns | 0.1973 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  17.918 ns |  1.2509 ns | 0.0686 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  29.874 ns |  3.0591 ns | 0.1677 ns |      - |         - |
-| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000**                 | **100**                  |   **4.408 ns** |  **0.1518 ns** | **0.0083 ns** |      **-** |         **-** |
-| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   4.104 ns |  0.3148 ns | 0.0173 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  10.530 ns |  0.4111 ns | 0.0225 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   7.554 ns |  0.1007 ns | 0.0055 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   5.029 ns |  0.2079 ns | 0.0114 ns |      - |         - |
-| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  20.509 ns |  0.5477 ns | 0.0300 ns |      - |         - |
-| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |   4.447 ns |  0.2894 ns | 0.0159 ns |      - |         - |
-| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  34.918 ns |  1.0153 ns | 0.0557 ns |      - |         - |
-| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  12.493 ns |  0.6296 ns | 0.0345 ns |      - |         - |
-| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  29.721 ns |  0.2429 ns | 0.0133 ns |      - |         - |
+| Method                    | Job                         | Runtime            | a                    | b                    | Mean        | Error      | StdDev    | Gen0   | Allocated |
+|-------------------------- |---------------------------- |------------------- |--------------------- |--------------------- |------------:|-----------:|----------:|-------:|----------:|
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)00000 [39]** | **1/1000000000000**      |  **25.9307 ns** |  **2.0808 ns** | **0.1141 ns** | **0.0029** |      **48 B** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |   4.1434 ns |  0.2349 ns | 0.0129 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  23.1432 ns |  1.1777 ns | 0.0646 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  22.4952 ns |  1.1108 ns | 0.0609 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)00000 [39] | 1/1000000000000      |  26.4647 ns |  4.9430 ns | 0.2709 ns | 0.0029 |      48 B |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  78.9724 ns |  1.0456 ns | 0.0573 ns | 0.0076 |      48 B |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |   8.6384 ns |  0.4644 ns | 0.0255 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  38.4268 ns |  0.8549 ns | 0.0469 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  19.6672 ns |  1.2033 ns | 0.0660 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)00000 [39] | 1/1000000000000      |  76.6361 ns |  6.8069 ns | 0.3731 ns | 0.0076 |      48 B |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024**                | **-1/1024**              |  **10.2409 ns** |  **0.5879 ns** | **0.0322 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   4.1173 ns |  0.1736 ns | 0.0095 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  10.8435 ns |  1.7616 ns | 0.0966 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |   7.7597 ns |  0.7293 ns | 0.0400 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -1024                | -1/1024              |  11.4499 ns |  0.5534 ns | 0.0303 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  43.9467 ns |  8.1405 ns | 0.4462 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  10.0413 ns |  2.7929 ns | 0.1531 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  35.0760 ns |  0.2347 ns | 0.0129 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  18.6478 ns |  1.6652 ns | 0.0913 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024                | -1/1024              |  40.5268 ns |  0.4142 ns | 0.0227 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45**                  | **1/6**                  |   **9.6279 ns** |  **0.1768 ns** | **0.0097 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   3.9599 ns |  0.1842 ns | 0.0101 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  11.2861 ns |  0.1618 ns | 0.0089 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |   7.5838 ns |  0.0559 ns | 0.0031 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | -45                  | 1/6                  |  10.9554 ns |  0.8365 ns | 0.0459 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  42.2684 ns |  1.9250 ns | 0.1055 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |   0.0983 ns |  0.1764 ns | 0.0097 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  35.0873 ns |  0.2472 ns | 0.0135 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  18.1556 ns |  1.1330 ns | 0.0621 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45                  | 1/6                  |  48.1374 ns |  1.6874 ns | 0.0925 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0**                    | **1**                    |   **8.4555 ns** |  **1.6107 ns** | **0.0883 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   3.9888 ns |  0.0818 ns | 0.0045 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  10.8258 ns |  0.8911 ns | 0.0488 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |   7.7915 ns |  0.5168 ns | 0.0283 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 0                    | 1                    |  12.2302 ns |  0.6932 ns | 0.0380 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  20.8711 ns |  0.7637 ns | 0.0419 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  10.0831 ns |  0.2156 ns | 0.0118 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  36.6802 ns | 21.5859 ns | 1.1832 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  18.1967 ns |  0.8106 ns | 0.0444 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0                    | 1                    |  19.0354 ns |  1.7059 ns | 0.0935 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |   **8.3071 ns** |  **0.2902 ns** | **0.0159 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.1131 ns |  0.3720 ns | 0.0204 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  10.6093 ns |  1.4916 ns | 0.0818 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   7.5600 ns |  0.3015 ns | 0.0165 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  12.2901 ns |  0.7834 ns | 0.0429 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  20.9045 ns |  0.1768 ns | 0.0097 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |   8.6338 ns |  1.2172 ns | 0.0667 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  35.0819 ns |  0.5219 ns | 0.0286 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  18.1965 ns |  0.4458 ns | 0.0244 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  18.2171 ns |  0.3493 ns | 0.0191 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **16.1522 ns** |  **0.5096 ns** | **0.0279 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |   3.9955 ns |  0.3439 ns | 0.0188 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  10.7283 ns |  0.2901 ns | 0.0159 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |   7.6096 ns |  0.3509 ns | 0.0192 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  17.0437 ns |  3.9058 ns | 0.2141 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  59.7929 ns |  5.0408 ns | 0.2763 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  10.3289 ns |  3.0919 ns | 0.1695 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  35.8168 ns | 19.9975 ns | 1.0961 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  18.7064 ns |  0.2550 ns | 0.0140 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  55.8550 ns |  3.3657 ns | 0.1845 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **88427(...)10656 [31]** | **88427(...)21312 [31]** |  **42.5380 ns** |  **0.1596 ns** | **0.0087 ns** | **0.0048** |      **80 B** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |   5.9396 ns |  0.1633 ns | 0.0089 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  62.3351 ns | 12.8325 ns | 0.7034 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  32.9847 ns |  4.1312 ns | 0.2264 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 88427(...)10656 [31] | 88427(...)21312 [31] |  46.7428 ns | 17.6025 ns | 0.9649 ns | 0.0048 |      80 B |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 124.5664 ns |  4.3992 ns | 0.2411 ns | 0.0126 |      80 B |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  21.8676 ns |  0.7438 ns | 0.0408 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  41.7827 ns | 14.9739 ns | 0.8208 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] |  24.7133 ns |  3.3290 ns | 0.1825 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 88427(...)10656 [31] | 88427(...)21312 [31] | 119.6512 ns |  5.0064 ns | 0.2744 ns | 0.0126 |      80 B |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **7.2223 ns** |  **0.1617 ns** | **0.0089 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   3.9597 ns |  0.2814 ns | 0.0154 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  10.8117 ns |  5.0375 ns | 0.2761 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   8.0077 ns |  0.3220 ns | 0.0176 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   9.2551 ns |  0.0645 ns | 0.0035 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  19.6779 ns |  0.3588 ns | 0.0197 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |   8.4708 ns |  1.0281 ns | 0.0564 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  29.7023 ns |  1.0054 ns | 0.0551 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  18.7782 ns |  0.3277 ns | 0.0180 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  16.2557 ns |  1.2514 ns | 0.0686 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **7.7889 ns** |  **2.1903 ns** | **0.1201 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   4.1099 ns |  0.0360 ns | 0.0020 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  11.4351 ns |  2.6529 ns | 0.1454 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   7.6080 ns |  0.6590 ns | 0.0361 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  11.7524 ns |  0.2787 ns | 0.0153 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  19.6512 ns |  1.1298 ns | 0.0619 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |   8.7839 ns |  0.1900 ns | 0.0104 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  35.5199 ns |  6.8176 ns | 0.3737 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  18.2101 ns |  0.2192 ns | 0.0120 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  17.8031 ns |  0.3559 ns | 0.0195 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **8.1919 ns** |  **0.3035 ns** | **0.0166 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   3.9600 ns |  0.1915 ns | 0.0105 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  11.3756 ns |  2.0537 ns | 0.1126 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   7.9658 ns |  0.0899 ns | 0.0049 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  11.6887 ns |  2.6693 ns | 0.1463 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  19.6517 ns |  0.2937 ns | 0.0161 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |   8.4539 ns |  0.5900 ns | 0.0323 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  35.2684 ns |  0.6948 ns | 0.0381 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  18.5218 ns |  0.2898 ns | 0.0159 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  24.5102 ns |  2.1059 ns | 0.1154 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97**                   | **89**                   |   **8.2909 ns** |  **2.8212 ns** | **0.1546 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   4.0985 ns |  0.0580 ns | 0.0032 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  10.6623 ns |  1.1736 ns | 0.0643 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |   7.7721 ns |  0.4086 ns | 0.0224 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 97                   | 89                   |  12.1407 ns |  0.5377 ns | 0.0295 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  20.6392 ns |  0.6838 ns | 0.0375 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  10.0072 ns |  1.6316 ns | 0.0894 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  15.1461 ns |  2.4549 ns | 0.1346 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  18.0904 ns |  1.7389 ns | 0.0953 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97                   | 89                   |  18.8601 ns |  0.3448 ns | 0.0189 ns |      - |         - |
+| **Equals**                    | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000**                 | **100**                  |   **8.1903 ns** |  **0.8252 ns** | **0.0452 ns** |      **-** |         **-** |
+| StrictEqualityEquals      | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   3.9370 ns |  0.1987 ns | 0.0109 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  11.3439 ns |  0.3192 ns | 0.0175 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |   7.8935 ns |  1.8804 ns | 0.1031 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET 8.0           | .NET 8.0           | 1000                 | 100                  |  12.0511 ns |  0.7923 ns | 0.0434 ns |      - |         - |
+| Equals                    | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  20.7390 ns |  0.1166 ns | 0.0064 ns |      - |         - |
+| StrictEqualityEquals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |   2.1761 ns |  1.2987 ns | 0.0712 ns |      - |         - |
+| GetHashCode               | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  35.8274 ns | 11.3816 ns | 0.6239 ns |      - |         - |
+| StrictEqualityGetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  18.6090 ns |  8.5141 ns | 0.4667 ns |      - |         - |
+| CompareTo                 | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000                 | 100                  |  18.7209 ns |  0.6563 ns | 0.0360 ns |      - |         - |

--- a/benchmarks/results/Fractions.Benchmarks.NonNormalizedComparisonBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.NonNormalizedComparisonBenchmarks-report-github.md
@@ -1,0 +1,104 @@
+```
+
+BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4412/22H2/2022Update)
+AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
+.NET SDK 8.0.300
+  [Host]                      : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET 8.0           : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun-.NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9241.0), X64 RyuJIT VectorSize=256
+
+IterationCount=3  LaunchCount=1  WarmupCount=3  
+
+```
+| Method      | Job                         | Runtime            | a                    | b                    | Mean       | Error      | StdDev    | Median     | Gen0   | Allocated |
+|------------ |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|-----------:|----------:|-----------:|-------:|----------:|
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/-96**               | **36/-96**               |   **4.531 ns** |  **0.2142 ns** | **0.0117 ns** |   **4.535 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  49.028 ns |  2.0206 ns | 0.1108 ns |  48.977 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |   4.910 ns |  0.3713 ns | 0.0203 ns |   4.913 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               |  20.679 ns |  0.1191 ns | 0.0065 ns |  20.681 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 213.533 ns |  2.3682 ns | 0.1298 ns | 213.476 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               |  29.926 ns |  1.0217 ns | 0.0560 ns |  29.939 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)000/1 [41]** | **1/1000000000000**      |  **25.124 ns** |  **1.2148 ns** | **0.0666 ns** |  **25.102 ns** | **0.0029** |      **48 B** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)000/1 [41] | 1/1000000000000      |  34.103 ns |  1.1074 ns | 0.0607 ns |  34.077 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)000/1 [41] | 1/1000000000000      |  25.031 ns |  7.3307 ns | 0.4018 ns |  24.866 ns | 0.0029 |      48 B |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  70.290 ns |  6.5724 ns | 0.3603 ns |  70.278 ns | 0.0076 |      48 B |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  77.280 ns |  4.1797 ns | 0.2291 ns |  77.162 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  79.723 ns |  4.2206 ns | 0.2313 ns |  79.755 ns | 0.0076 |      48 B |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024/1**              | **-1/1024**              |   **9.622 ns** |  **0.7744 ns** | **0.0424 ns** |   **9.628 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1024/1              | -1/1024              |  25.162 ns |  0.2693 ns | 0.0148 ns |  25.167 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -1024/1              | -1/1024              |   9.528 ns |  1.2665 ns | 0.0694 ns |   9.510 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  36.176 ns |  2.1338 ns | 0.1170 ns |  36.142 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  76.462 ns |  1.5314 ns | 0.0839 ns |  76.479 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  44.022 ns |  6.8040 ns | 0.3729 ns |  43.846 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45/1**                | **1/6**                  |  **10.033 ns** |  **1.8346 ns** | **0.1006 ns** |   **9.997 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -45/1                | 1/6                  |  23.978 ns |  1.3986 ns | 0.0767 ns |  23.936 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -45/1                | 1/6                  |   9.236 ns |  0.7905 ns | 0.0433 ns |   9.223 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  35.351 ns |  0.6343 ns | 0.0348 ns |  35.357 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  70.805 ns |  7.5015 ns | 0.4112 ns |  70.756 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  43.478 ns |  0.8332 ns | 0.0457 ns |  43.453 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0/1**                  | **1/1**                  |   **4.406 ns** |  **0.1591 ns** | **0.0087 ns** |   **4.408 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 0/1                  | 1/1                  |  19.173 ns |  1.0925 ns | 0.0599 ns |  19.151 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 0/1                  | 1/1                  |   4.798 ns |  0.1580 ns | 0.0087 ns |   4.802 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  20.680 ns |  0.3032 ns | 0.0166 ns |  20.674 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  61.518 ns |  6.5401 ns | 0.3585 ns |  61.322 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  24.352 ns |  0.8618 ns | 0.0472 ns |  24.356 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |   **4.720 ns** |  **0.0117 ns** | **0.0006 ns** |   **4.720 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  32.880 ns |  1.6857 ns | 0.0924 ns |  32.904 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.919 ns |  0.1662 ns | 0.0091 ns |   4.915 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  20.492 ns |  0.2054 ns | 0.0113 ns |  20.486 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 155.598 ns | 64.2601 ns | 3.5223 ns | 157.629 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  29.858 ns |  0.8319 ns | 0.0456 ns |  29.870 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **135/1000**             | **76/1000**              |   **4.386 ns** |  **0.2493 ns** | **0.0137 ns** |   **4.384 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 135/1000             | 76/1000              |  50.231 ns |  0.8581 ns | 0.0470 ns |  50.232 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 135/1000             | 76/1000              |   4.913 ns |  0.3947 ns | 0.0216 ns |   4.919 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              |  20.668 ns |  2.3379 ns | 0.1281 ns |  20.601 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              | 220.514 ns | 36.8357 ns | 2.0191 ns | 220.450 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              |  29.798 ns |  1.6929 ns | 0.0928 ns |  29.799 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **16.210 ns** |  **3.7747 ns** | **0.2069 ns** |  **16.120 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  31.093 ns | 11.5649 ns | 0.6339 ns |  30.889 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  15.100 ns |  3.3493 ns | 0.1836 ns |  15.064 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  55.285 ns |  0.8042 ns | 0.0441 ns |  55.266 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 150.644 ns | 13.5802 ns | 0.7444 ns | 150.933 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  60.466 ns |  4.9183 ns | 0.2696 ns |  60.314 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/66**                | **36/96**                |  **16.351 ns** |  **2.8856 ns** | **0.1582 ns** |  **16.428 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  53.403 ns |  9.3933 ns | 0.5149 ns |  53.487 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  15.005 ns |  0.0705 ns | 0.0039 ns |  15.006 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                |  55.965 ns |  4.6435 ns | 0.2545 ns |  56.004 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 212.663 ns | 13.8767 ns | 0.7606 ns | 213.094 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                |  60.632 ns |  8.3203 ns | 0.4561 ns |  60.459 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **70742(...)85248 [33]** | **70742(...)70496 [33]** |  **41.948 ns** |  **2.9570 ns** | **0.1621 ns** |  **41.892 ns** | **0.0048** |      **80 B** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 70742(...)85248 [33] | 70742(...)70496 [33] | 216.571 ns |  6.6989 ns | 0.3672 ns | 216.576 ns | 0.0076 |     128 B |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 70742(...)85248 [33] | 70742(...)70496 [33] |  40.849 ns |  4.8493 ns | 0.2658 ns |  40.965 ns | 0.0048 |      80 B |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 114.215 ns |  2.1830 ns | 0.1197 ns | 114.164 ns | 0.0126 |      80 B |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 311.625 ns |  8.1727 ns | 0.4480 ns | 311.619 ns | 0.0305 |     193 B |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 126.897 ns |  7.0170 ns | 0.3846 ns | 127.085 ns | 0.0126 |      80 B |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **3.744 ns** |  **0.1073 ns** | **0.0059 ns** |   **3.747 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  35.171 ns |  0.7876 ns | 0.0432 ns |  35.194 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   2.267 ns |  0.0662 ns | 0.0036 ns |   2.266 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  19.480 ns |  0.3110 ns | 0.0170 ns |  19.473 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  | 113.250 ns | 35.6056 ns | 1.9517 ns | 112.139 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  21.791 ns |  1.0232 ns | 0.0561 ns |  21.763 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **3.758 ns** |  **0.0694 ns** | **0.0038 ns** |   **3.757 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  34.970 ns |  5.2858 ns | 0.2897 ns |  34.870 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   5.202 ns |  2.0040 ns | 0.1098 ns |   5.245 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |   4.929 ns | 42.0201 ns | 2.3033 ns |   3.697 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   | 117.691 ns | 15.4769 ns | 0.8483 ns | 117.360 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  28.947 ns |  2.5040 ns | 0.1373 ns |  28.982 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **3.763 ns** |  **0.2616 ns** | **0.0143 ns** |   **3.755 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  34.226 ns |  1.3631 ns | 0.0747 ns |  34.261 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   4.732 ns |  0.2098 ns | 0.0115 ns |   4.729 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  19.784 ns |  0.6998 ns | 0.0384 ns |  19.789 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    | 111.322 ns |  6.3846 ns | 0.3500 ns | 111.269 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  29.935 ns |  0.2120 ns | 0.0116 ns |  29.932 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97/1**                 | **89/1**                 |   **4.720 ns** |  **0.2070 ns** | **0.0113 ns** |   **4.725 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 97/1                 | 89/1                 |  23.945 ns |  0.2926 ns | 0.0160 ns |  23.954 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 97/1                 | 89/1                 |   4.917 ns |  0.1458 ns | 0.0080 ns |   4.922 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  20.528 ns |  0.4315 ns | 0.0237 ns |  20.518 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  72.657 ns |  6.3854 ns | 0.3500 ns |  72.639 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  30.003 ns |  4.0912 ns | 0.2243 ns |  29.883 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000/1**               | **100/1**                |   **3.781 ns** |  **0.1308 ns** | **0.0072 ns** |   **3.782 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 1000/1               | 100/1                |  24.028 ns |  2.5236 ns | 0.1383 ns |  23.949 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 1000/1               | 100/1                |   5.030 ns |  0.1594 ns | 0.0087 ns |   5.031 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  20.537 ns |  0.9259 ns | 0.0508 ns |  20.552 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  70.439 ns |  5.2024 ns | 0.2852 ns |  70.294 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  29.886 ns |  0.5233 ns | 0.0287 ns |  29.890 ns |      - |         - |

--- a/benchmarks/results/Fractions.Benchmarks.NonNormalizedComparisonBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.NonNormalizedComparisonBenchmarks-report-github.md
@@ -10,95 +10,95 @@ AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
 IterationCount=3  LaunchCount=1  WarmupCount=3  
 
 ```
-| Method      | Job                         | Runtime            | a                    | b                    | Mean       | Error      | StdDev    | Median     | Gen0   | Allocated |
-|------------ |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|-----------:|----------:|-----------:|-------:|----------:|
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/-96**               | **36/-96**               |   **4.531 ns** |  **0.2142 ns** | **0.0117 ns** |   **4.535 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  49.028 ns |  2.0206 ns | 0.1108 ns |  48.977 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |   4.910 ns |  0.3713 ns | 0.0203 ns |   4.913 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               |  20.679 ns |  0.1191 ns | 0.0065 ns |  20.681 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 213.533 ns |  2.3682 ns | 0.1298 ns | 213.476 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               |  29.926 ns |  1.0217 ns | 0.0560 ns |  29.939 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)000/1 [41]** | **1/1000000000000**      |  **25.124 ns** |  **1.2148 ns** | **0.0666 ns** |  **25.102 ns** | **0.0029** |      **48 B** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)000/1 [41] | 1/1000000000000      |  34.103 ns |  1.1074 ns | 0.0607 ns |  34.077 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)000/1 [41] | 1/1000000000000      |  25.031 ns |  7.3307 ns | 0.4018 ns |  24.866 ns | 0.0029 |      48 B |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  70.290 ns |  6.5724 ns | 0.3603 ns |  70.278 ns | 0.0076 |      48 B |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  77.280 ns |  4.1797 ns | 0.2291 ns |  77.162 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  79.723 ns |  4.2206 ns | 0.2313 ns |  79.755 ns | 0.0076 |      48 B |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024/1**              | **-1/1024**              |   **9.622 ns** |  **0.7744 ns** | **0.0424 ns** |   **9.628 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1024/1              | -1/1024              |  25.162 ns |  0.2693 ns | 0.0148 ns |  25.167 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -1024/1              | -1/1024              |   9.528 ns |  1.2665 ns | 0.0694 ns |   9.510 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  36.176 ns |  2.1338 ns | 0.1170 ns |  36.142 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  76.462 ns |  1.5314 ns | 0.0839 ns |  76.479 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  44.022 ns |  6.8040 ns | 0.3729 ns |  43.846 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45/1**                | **1/6**                  |  **10.033 ns** |  **1.8346 ns** | **0.1006 ns** |   **9.997 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -45/1                | 1/6                  |  23.978 ns |  1.3986 ns | 0.0767 ns |  23.936 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -45/1                | 1/6                  |   9.236 ns |  0.7905 ns | 0.0433 ns |   9.223 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  35.351 ns |  0.6343 ns | 0.0348 ns |  35.357 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  70.805 ns |  7.5015 ns | 0.4112 ns |  70.756 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  43.478 ns |  0.8332 ns | 0.0457 ns |  43.453 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0/1**                  | **1/1**                  |   **4.406 ns** |  **0.1591 ns** | **0.0087 ns** |   **4.408 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 0/1                  | 1/1                  |  19.173 ns |  1.0925 ns | 0.0599 ns |  19.151 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 0/1                  | 1/1                  |   4.798 ns |  0.1580 ns | 0.0087 ns |   4.802 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  20.680 ns |  0.3032 ns | 0.0166 ns |  20.674 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  61.518 ns |  6.5401 ns | 0.3585 ns |  61.322 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  24.352 ns |  0.8618 ns | 0.0472 ns |  24.356 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |   **4.720 ns** |  **0.0117 ns** | **0.0006 ns** |   **4.720 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  32.880 ns |  1.6857 ns | 0.0924 ns |  32.904 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |   4.919 ns |  0.1662 ns | 0.0091 ns |   4.915 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  20.492 ns |  0.2054 ns | 0.0113 ns |  20.486 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 155.598 ns | 64.2601 ns | 3.5223 ns | 157.629 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  29.858 ns |  0.8319 ns | 0.0456 ns |  29.870 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **135/1000**             | **76/1000**              |   **4.386 ns** |  **0.2493 ns** | **0.0137 ns** |   **4.384 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 135/1000             | 76/1000              |  50.231 ns |  0.8581 ns | 0.0470 ns |  50.232 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 135/1000             | 76/1000              |   4.913 ns |  0.3947 ns | 0.0216 ns |   4.919 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              |  20.668 ns |  2.3379 ns | 0.1281 ns |  20.601 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              | 220.514 ns | 36.8357 ns | 2.0191 ns | 220.450 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              |  29.798 ns |  1.6929 ns | 0.0928 ns |  29.799 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **16.210 ns** |  **3.7747 ns** | **0.2069 ns** |  **16.120 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  31.093 ns | 11.5649 ns | 0.6339 ns |  30.889 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  15.100 ns |  3.3493 ns | 0.1836 ns |  15.064 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  55.285 ns |  0.8042 ns | 0.0441 ns |  55.266 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 150.644 ns | 13.5802 ns | 0.7444 ns | 150.933 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  60.466 ns |  4.9183 ns | 0.2696 ns |  60.314 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/66**                | **36/96**                |  **16.351 ns** |  **2.8856 ns** | **0.1582 ns** |  **16.428 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  53.403 ns |  9.3933 ns | 0.5149 ns |  53.487 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  15.005 ns |  0.0705 ns | 0.0039 ns |  15.006 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                |  55.965 ns |  4.6435 ns | 0.2545 ns |  56.004 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 212.663 ns | 13.8767 ns | 0.7606 ns | 213.094 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                |  60.632 ns |  8.3203 ns | 0.4561 ns |  60.459 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **70742(...)85248 [33]** | **70742(...)70496 [33]** |  **41.948 ns** |  **2.9570 ns** | **0.1621 ns** |  **41.892 ns** | **0.0048** |      **80 B** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 70742(...)85248 [33] | 70742(...)70496 [33] | 216.571 ns |  6.6989 ns | 0.3672 ns | 216.576 ns | 0.0076 |     128 B |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 70742(...)85248 [33] | 70742(...)70496 [33] |  40.849 ns |  4.8493 ns | 0.2658 ns |  40.965 ns | 0.0048 |      80 B |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 114.215 ns |  2.1830 ns | 0.1197 ns | 114.164 ns | 0.0126 |      80 B |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 311.625 ns |  8.1727 ns | 0.4480 ns | 311.619 ns | 0.0305 |     193 B |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 126.897 ns |  7.0170 ns | 0.3846 ns | 127.085 ns | 0.0126 |      80 B |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **3.744 ns** |  **0.1073 ns** | **0.0059 ns** |   **3.747 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  35.171 ns |  0.7876 ns | 0.0432 ns |  35.194 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   2.267 ns |  0.0662 ns | 0.0036 ns |   2.266 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  19.480 ns |  0.3110 ns | 0.0170 ns |  19.473 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  | 113.250 ns | 35.6056 ns | 1.9517 ns | 112.139 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  21.791 ns |  1.0232 ns | 0.0561 ns |  21.763 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **3.758 ns** |  **0.0694 ns** | **0.0038 ns** |   **3.757 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  34.970 ns |  5.2858 ns | 0.2897 ns |  34.870 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |   5.202 ns |  2.0040 ns | 0.1098 ns |   5.245 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |   4.929 ns | 42.0201 ns | 2.3033 ns |   3.697 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   | 117.691 ns | 15.4769 ns | 0.8483 ns | 117.360 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  28.947 ns |  2.5040 ns | 0.1373 ns |  28.982 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **3.763 ns** |  **0.2616 ns** | **0.0143 ns** |   **3.755 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  34.226 ns |  1.3631 ns | 0.0747 ns |  34.261 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |   4.732 ns |  0.2098 ns | 0.0115 ns |   4.729 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  19.784 ns |  0.6998 ns | 0.0384 ns |  19.789 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    | 111.322 ns |  6.3846 ns | 0.3500 ns | 111.269 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  29.935 ns |  0.2120 ns | 0.0116 ns |  29.932 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97/1**                 | **89/1**                 |   **4.720 ns** |  **0.2070 ns** | **0.0113 ns** |   **4.725 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 97/1                 | 89/1                 |  23.945 ns |  0.2926 ns | 0.0160 ns |  23.954 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 97/1                 | 89/1                 |   4.917 ns |  0.1458 ns | 0.0080 ns |   4.922 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  20.528 ns |  0.4315 ns | 0.0237 ns |  20.518 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  72.657 ns |  6.3854 ns | 0.3500 ns |  72.639 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  30.003 ns |  4.0912 ns | 0.2243 ns |  29.883 ns |      - |         - |
-| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000/1**               | **100/1**                |   **3.781 ns** |  **0.1308 ns** | **0.0072 ns** |   **3.782 ns** |      **-** |         **-** |
-| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 1000/1               | 100/1                |  24.028 ns |  2.5236 ns | 0.1383 ns |  23.949 ns |      - |         - |
-| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 1000/1               | 100/1                |   5.030 ns |  0.1594 ns | 0.0087 ns |   5.031 ns |      - |         - |
-| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  20.537 ns |  0.9259 ns | 0.0508 ns |  20.552 ns |      - |         - |
-| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  70.439 ns |  5.2024 ns | 0.2852 ns |  70.294 ns |      - |         - |
-| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  29.886 ns |  0.5233 ns | 0.0287 ns |  29.890 ns |      - |         - |
+| Method      | Job                         | Runtime            | a                    | b                    | Mean       | Error       | StdDev    | Gen0   | Allocated |
+|------------ |---------------------------- |------------------- |--------------------- |--------------------- |-----------:|------------:|----------:|-------:|----------:|
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1000(...)000/1 [41]** | **1/1000000000000**      |  **25.191 ns** |   **0.4908 ns** | **0.0269 ns** | **0.0029** |      **48 B** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)000/1 [41] | 1/1000000000000      |  33.880 ns |   2.7924 ns | 0.1531 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -1000(...)000/1 [41] | 1/1000000000000      |  27.178 ns |   2.5203 ns | 0.1381 ns | 0.0029 |      48 B |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  75.562 ns |   5.3203 ns | 0.2916 ns | 0.0076 |      48 B |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  77.487 ns |   1.6428 ns | 0.0900 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1000(...)000/1 [41] | 1/1000000000000      |  76.814 ns |  12.3789 ns | 0.6785 ns | 0.0076 |      48 B |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-1024/1**              | **-1/1024**              |  **10.245 ns** |   **0.2966 ns** | **0.0163 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -1024/1              | -1/1024              |  25.005 ns |   0.1660 ns | 0.0091 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -1024/1              | -1/1024              |  11.342 ns |   0.3166 ns | 0.0174 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  45.939 ns |   3.9878 ns | 0.2186 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  75.691 ns |   2.7205 ns | 0.1491 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -1024/1              | -1/1024              |  40.705 ns |   2.5724 ns | 0.1410 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **-45/1**                | **1/6**                  |   **9.453 ns** |   **0.1376 ns** | **0.0075 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | -45/1                | 1/6                  |  23.996 ns |   2.6495 ns | 0.1452 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | -45/1                | 1/6                  |  11.067 ns |   1.2258 ns | 0.0672 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  42.559 ns |   2.2044 ns | 0.1208 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  86.635 ns |   6.7422 ns | 0.3696 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | -45/1                | 1/6                  |  40.267 ns |   7.9585 ns | 0.4362 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/-96**               | **36/-96**               |   **8.551 ns** |   **0.4951 ns** | **0.0271 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |  49.581 ns |   0.9535 ns | 0.0523 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 42/-96               | 36/-96               |   9.721 ns |   1.4531 ns | 0.0797 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               |  20.851 ns |   1.0540 ns | 0.0578 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               | 212.615 ns |   2.9906 ns | 0.1639 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/-96               | 36/-96               |  18.505 ns |   0.6120 ns | 0.0335 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **0/1**                  | **1/1**                  |   **8.063 ns** |   **0.3752 ns** | **0.0206 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 0/1                  | 1/1                  |  19.717 ns |   1.4119 ns | 0.0774 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 0/1                  | 1/1                  |  12.074 ns |   0.3015 ns | 0.0165 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  20.902 ns |   0.3838 ns | 0.0210 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  62.771 ns |  15.0593 ns | 0.8255 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 0/1                  | 1/1                  |  18.983 ns |   0.6862 ns | 0.0376 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **77/3600**              | **37/3600**              |   **8.246 ns** |   **2.5989 ns** | **0.1425 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  32.648 ns |   2.2979 ns | 0.1260 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 77/3600              | 37/3600              |  12.019 ns |   0.2533 ns | 0.0139 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  20.630 ns |   1.0169 ns | 0.0557 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              | 153.460 ns |  31.4009 ns | 1.7212 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 77/3600              | 37/3600              |  18.647 ns |   0.3353 ns | 0.0184 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **135/1000**             | **76/1000**              |   **8.438 ns** |   **0.8012 ns** | **0.0439 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 135/1000             | 76/1000              |  50.488 ns |   1.2601 ns | 0.0691 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 135/1000             | 76/1000              |  12.356 ns |   1.3681 ns | 0.0750 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              |  20.641 ns |   0.5961 ns | 0.0327 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              | 219.731 ns |  11.7438 ns | 0.6437 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 135/1000             | 76/1000              |  18.745 ns |   1.2384 ns | 0.0679 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **27/200**               | **19/250**               |  **16.844 ns** |   **0.4270 ns** | **0.0234 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  30.741 ns |   1.4927 ns | 0.0818 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 27/200               | 19/250               |  17.336 ns |   0.4595 ns | 0.0252 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  59.974 ns |   2.7408 ns | 0.1502 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               | 140.120 ns |   5.1339 ns | 0.2814 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 27/200               | 19/250               |  55.868 ns |   4.7321 ns | 0.2594 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **42/66**                | **36/96**                |  **16.090 ns** |   **1.5363 ns** | **0.0842 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  50.614 ns |   9.1213 ns | 0.5000 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 42/66                | 36/96                |  17.831 ns |   1.0544 ns | 0.0578 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                |  62.388 ns |   3.0223 ns | 0.1657 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                | 213.112 ns |   6.3972 ns | 0.3507 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 42/66                | 36/96                |  55.804 ns |   2.7767 ns | 0.1522 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **70742(...)85248 [33]** | **70742(...)70496 [33]** |  **43.403 ns** |   **5.4860 ns** | **0.3007 ns** | **0.0048** |      **80 B** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 70742(...)85248 [33] | 70742(...)70496 [33] | 222.331 ns | 104.5301 ns | 5.7296 ns | 0.0076 |     128 B |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 70742(...)85248 [33] | 70742(...)70496 [33] |  46.273 ns |   4.2904 ns | 0.2352 ns | 0.0048 |      80 B |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 129.983 ns |  79.6828 ns | 4.3677 ns | 0.0126 |      80 B |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 313.413 ns |  44.7530 ns | 2.4531 ns | 0.0305 |     193 B |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 70742(...)85248 [33] | 70742(...)70496 [33] | 120.376 ns |   8.3459 ns | 0.4575 ns | 0.0126 |      80 B |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **NaN**                  |   **7.579 ns** |   **0.2095 ns** | **0.0115 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |  35.467 ns |   0.9376 ns | 0.0514 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | NaN                  |   9.300 ns |   1.9475 ns | 0.1067 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  20.154 ns |  12.2857 ns | 0.6734 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  | 113.144 ns |  61.5663 ns | 3.3747 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | NaN                  |  16.609 ns |   1.7859 ns | 0.0979 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **-∞**                   |   **7.424 ns** |   **0.8610 ns** | **0.0472 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  35.387 ns |   6.9313 ns | 0.3799 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | -∞                   |  11.674 ns |   1.8262 ns | 0.1001 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  20.025 ns |   6.0034 ns | 0.3291 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   | 112.339 ns |  10.0400 ns | 0.5503 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | -∞                   |  18.327 ns |   4.7829 ns | 0.2622 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **245850922/78256779**   | **0**                    |   **7.817 ns** |   **2.8960 ns** | **0.1587 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  35.353 ns |   3.6170 ns | 0.1983 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 245850922/78256779   | 0                    |  12.126 ns |   1.2395 ns | 0.0679 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  19.822 ns |   0.2765 ns | 0.0152 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    | 113.698 ns |  17.2699 ns | 0.9466 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 245850922/78256779   | 0                    |  24.462 ns |   2.8591 ns | 0.1567 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **97/1**                 | **89/1**                 |   **8.241 ns** |   **0.8776 ns** | **0.0481 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 97/1                 | 89/1                 |  24.267 ns |   1.5769 ns | 0.0864 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 97/1                 | 89/1                 |  12.277 ns |   4.9064 ns | 0.2689 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  21.096 ns |   6.4232 ns | 0.3521 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  72.873 ns |  30.3014 ns | 1.6609 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 97/1                 | 89/1                 |  18.777 ns |   0.9448 ns | 0.0518 ns |      - |         - |
+| **Equals**      | **ShortRun-.NET 8.0**           | **.NET 8.0**           | **1000/1**               | **100/1**                |   **8.805 ns** |   **4.1742 ns** | **0.2288 ns** |      **-** |         **-** |
+| GetHashCode | ShortRun-.NET 8.0           | .NET 8.0           | 1000/1               | 100/1                |  24.385 ns |   0.9475 ns | 0.0519 ns |      - |         - |
+| CompareTo   | ShortRun-.NET 8.0           | .NET 8.0           | 1000/1               | 100/1                |  12.131 ns |   0.4425 ns | 0.0243 ns |      - |         - |
+| Equals      | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  20.711 ns |   0.6997 ns | 0.0384 ns |      - |         - |
+| GetHashCode | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  72.295 ns |   8.2043 ns | 0.4497 ns |      - |         - |
+| CompareTo   | ShortRun-.NET Framework 4.8 | .NET Framework 4.8 | 1000/1               | 100/1                |  18.869 ns |   0.5865 ns | 0.0321 ns |      - |         - |

--- a/src/Fractions/Comparers/FractionComparer.cs
+++ b/src/Fractions/Comparers/FractionComparer.cs
@@ -13,6 +13,9 @@ public abstract class FractionComparer :
     /// <inheritdoc cref="FractionValueEqualityComparer" path="/summary"/>>
     public static FractionComparer ValueEquality { get; } = new FractionValueEqualityComparer();
 
+    /// <inheritdoc cref="FractionStrictEqualityComparer" path="/summary"/>>
+    public static FractionComparer StrictEquality { get; } = new FractionStrictEqualityComparer();
+
     /// <inheritdoc />
     public abstract bool Equals(Fraction x, Fraction y);
 

--- a/src/Fractions/Comparers/FractionComparer.cs
+++ b/src/Fractions/Comparers/FractionComparer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Fractions;
+
+/// <summary>
+/// Represents a <see cref="Fraction"/> comparison operation that uses specific rules.
+/// </summary>
+public abstract class FractionComparer :
+    IEqualityComparer<Fraction>,
+    IEqualityComparer {
+    /// <inheritdoc cref="FractionValueEqualityComparer" path="/summary"/>>
+    public static FractionComparer ValueEquality { get; } = new FractionValueEqualityComparer();
+
+    /// <inheritdoc />
+    public abstract bool Equals(Fraction x, Fraction y);
+
+    /// <inheritdoc />
+    public abstract int GetHashCode(Fraction obj);
+
+    /// <inheritdoc cref="IEqualityComparer.Equals(object,object)"/>>
+    public new bool Equals(object x, object y) {
+        if (ReferenceEquals(x, y)) {
+            return true;
+        }
+
+        if (x is null || y is null) {
+            return false;
+        }
+
+        return (x is Fraction f1 && y is Fraction f2)
+            ? Equals(f1, f2)
+            : x.Equals(y);
+    }
+
+    /// <inheritdoc />
+    bool IEqualityComparer.Equals(object x, object y) => Equals(x, y);
+
+    /// <inheritdoc cref="IEqualityComparer.GetHashCode(object)"/>>
+    public int GetHashCode(object obj) {
+        if (obj is null) {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        return obj is Fraction f
+            ? GetHashCode(f)
+            : obj.GetHashCode();
+    }
+
+    /// <inheritdoc />
+    int IEqualityComparer.GetHashCode(object obj) => GetHashCode(obj);
+}

--- a/src/Fractions/Comparers/FractionStrictEqualityComparer.cs
+++ b/src/Fractions/Comparers/FractionStrictEqualityComparer.cs
@@ -1,0 +1,18 @@
+﻿namespace Fractions;
+
+/// <summary>
+/// A comparator that checks the numerators and denominators of two fractions. The values ​​must be exactly the same.
+/// </summary>
+public sealed class FractionStrictEqualityComparer : FractionComparer {
+    /// <inheritdoc />
+    public override bool Equals(Fraction x, Fraction y) {
+        return x.Numerator == y.Numerator && x.Denominator == y.Denominator;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode(Fraction obj) {
+        unchecked {
+            return (obj.Denominator.GetHashCode() * 397) ^ obj.Numerator.GetHashCode();
+        }
+    }
+}

--- a/src/Fractions/Comparers/FractionValueEqualityComparer.cs
+++ b/src/Fractions/Comparers/FractionValueEqualityComparer.cs
@@ -34,7 +34,8 @@ public sealed class FractionValueEqualityComparer : FractionComparer
         }
 
         // both values are non-zero fractions with different denominators  
-        return (numerator1 * denominator2) == (numerator2 * denominator1);
+        return Fraction.MultiplyTerms(ref numerator1, ref denominator2) ==
+               Fraction.MultiplyTerms(ref numerator2, ref denominator1);
     }
 
     /// <inheritdoc />

--- a/src/Fractions/Comparers/FractionValueEqualityComparer.cs
+++ b/src/Fractions/Comparers/FractionValueEqualityComparer.cs
@@ -7,10 +7,6 @@ public class FractionValueEqualityComparer : FractionComparer
 {
     /// <inheritdoc />
     public override bool Equals(Fraction x, Fraction y) {
-        if (x.IsNaN || y.IsNaN) {
-            return false; // special case (NaN values are not considered equal)
-        }
-
         // normalize (if needed)
         var a = x.Reduce(); 
         var b = y.Reduce();

--- a/src/Fractions/Comparers/FractionValueEqualityComparer.cs
+++ b/src/Fractions/Comparers/FractionValueEqualityComparer.cs
@@ -3,16 +3,38 @@
 /// <summary>
 /// A comparator that checks two fractions for equality of value. It doesn't matter whether the numerator and denominator were reduced to the lowest common denominator.
 /// </summary>
-public class FractionValueEqualityComparer : FractionComparer
+public sealed class FractionValueEqualityComparer : FractionComparer
 {
     /// <inheritdoc />
     public override bool Equals(Fraction x, Fraction y) {
-        // normalize (if needed)
-        var a = x.Reduce(); 
-        var b = y.Reduce();
+        var numerator1 = x.Numerator;
+        var denominator1 = x.Denominator;
+        var numerator2 = y.Numerator;
+        var denominator2 = y.Denominator;
 
-        // test for value equality
-        return a.Numerator == b.Numerator && a.Denominator == b.Denominator;
+        if (denominator1 == denominator2) { 
+            return denominator1.IsZero
+                ? numerator1.Sign == numerator2.Sign // both fractions represent infinities
+                : numerator1 == numerator2;
+        }
+
+        if (denominator1.IsZero || denominator2.IsZero) {
+            // either x or y is NaN or infinity.
+            return false;
+        }
+
+        if (numerator1.IsZero && numerator2.IsZero) {
+            // both values are 0
+            return true;
+        }
+
+        if (numerator1.IsZero || numerator2.IsZero) {
+            // either x or y has the value 0
+            return false;
+        }
+
+        // both values are non-zero fractions with different denominators  
+        return (numerator1 * denominator2) == (numerator2 * denominator1);
     }
 
     /// <inheritdoc />

--- a/src/Fractions/Comparers/FractionValueEqualityComparer.cs
+++ b/src/Fractions/Comparers/FractionValueEqualityComparer.cs
@@ -1,0 +1,29 @@
+﻿namespace Fractions;
+
+/// <summary>
+/// A comparator that checks two fractions for equality of value. It doesn't matter whether the numerator and denominator were reduced to the lowest common denominator.
+/// </summary>
+public class FractionValueEqualityComparer : FractionComparer
+{
+    /// <inheritdoc />
+    public override bool Equals(Fraction x, Fraction y) {
+        if (x.IsNaN || y.IsNaN) {
+            return false; // special case (NaN values are not considered equal)
+        }
+
+        // normalize (if needed)
+        var a = x.Reduce(); 
+        var b = y.Reduce();
+
+        // test for value equality
+        return a.Numerator == b.Numerator && a.Denominator == b.Denominator;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode(Fraction obj) {
+        var fraction = obj.Reduce();
+        unchecked {
+            return (fraction.Denominator.GetHashCode() * 397) ^ fraction.Numerator.GetHashCode();
+        }
+    }
+}

--- a/src/Fractions/Fraction.CompareTo.cs
+++ b/src/Fractions/Fraction.CompareTo.cs
@@ -38,19 +38,27 @@ public readonly partial struct Fraction
     /// </returns>
     /// <remarks>Comparing with <see cref="NaN" /> as the first argument always returns -1</remarks>
     public int CompareTo(Fraction other) {
-        if (IsNaN) {
-            return other.IsNaN ? 0 : -1;
-        }
-
-        if (other.IsNaN) {
-            return 1;
-        }
-        
         var numerator1 = Numerator;
         var denominator1 = Denominator;
         var numerator2 = other.Numerator;
         var denominator2 = other.Denominator;
-        
+
+        // normalize signs
+        numerator1 = denominator1.Sign == -1 ? -numerator1 : numerator1;
+        denominator1 = denominator1.Sign == -1 ? -denominator1 : denominator1;
+        numerator2 = denominator2.Sign == -1 ? -numerator2 : numerator2;
+        denominator2 = denominator2.Sign == -1 ? -denominator2 : denominator2;
+
+        if (numerator1.IsZero && denominator1.IsZero) {
+            // this is NaN
+            return (numerator2.IsZero && denominator2.IsZero) ? 0 : -1;
+        }
+
+        if (numerator2.IsZero && denominator2.IsZero) {
+            // other is NaN
+            return 1;
+        }
+
         if (denominator1 == denominator2) { 
             return denominator1.IsZero ? 
                 numerator1.Sign.CompareTo(numerator2.Sign) :  // both fractions represent infinities
@@ -74,6 +82,7 @@ public readonly partial struct Fraction
         }
 
         // both values are non-zero fractions with different denominators  
-        return (numerator1 * denominator2).CompareTo(numerator2 * denominator1);
+        return MultiplyTerms(ref numerator1, ref denominator2)
+            .CompareTo(MultiplyTerms(ref numerator2, ref denominator1));
     }
 }

--- a/src/Fractions/Fraction.CompareTo.cs
+++ b/src/Fractions/Fraction.CompareTo.cs
@@ -78,7 +78,7 @@ public readonly partial struct Fraction
         }
 
         if (denominator2.IsZero) {
-            return numerator2.Sign; // PositiveInfinity -> -1, NegativeInfinity -> 1
+            return -numerator2.Sign; // PositiveInfinity -> -1, NegativeInfinity -> 1
         }
 
         // both values are non-zero fractions with different denominators  

--- a/src/Fractions/Fraction.Equality.cs
+++ b/src/Fractions/Fraction.Equality.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 
 namespace Fractions;
 
@@ -17,47 +18,21 @@ public readonly partial struct Fraction {
     }
 
     /// <summary>
-    ///     <para>Performs an exact comparison with <paramref name="other" /> using numerator and denominator.</para>
-    ///     <para>Warning: 1/2 is NOT equal to 2/4! -1/2 is NOT equal to 1/-2!</para>
-    ///     <para>
-    ///         If you want to test the calculated values for equality use <see cref="CompareTo(Fraction)" /> or
-    ///         <see cref="IsEquivalentTo" />
-    ///     </para>
+    /// Compares whether the value of two fractions is the same
     /// </summary>
     /// <param name="other">The fraction to compare with.</param>
-    /// <returns>
-    ///     <c>true</c> if numerator and denominator of both fractions are equal, and neither of them is
-    ///     <see cref="NaN" />.
-    /// </returns>
+    /// <returns>Is <c>true</c> if both fractions have the same value. Otherwise <c>false</c>.</returns>
     public bool Equals(Fraction other) {
         return FractionComparer.ValueEquality.Equals(this, other);
     }
 
-    /// <summary>
-    ///     <para>Performs an exact comparison with <paramref name="other" /> using numerator and denominator.</para>
-    ///     <para>Warning: 1/2 is NOT equal to 2/4! -1/2 is NOT equal to 1/-2!</para>
-    ///     <para>
-    ///         If you want to test the calculated values for equality use <see cref="CompareTo(Fraction)" /> or
-    ///         <see cref="IsEquivalentTo" />
-    ///     </para>
-    /// </summary>
-    /// <param name="other">The fraction to compare with.</param>
-    /// <returns>
-    ///     <c>true</c> if <paramref name="other" /> is type of <see cref="Fraction" /> and numerator and denominator of
-    ///     both are equal, and neither of them is <see cref="NaN" />.
-    /// </returns>
+    /// <inheritdoc cref="Equals(Fraction)"/>
     public override bool Equals(object other) {
         return other is Fraction fraction && Equals(fraction);
     }
 
-    /// <summary>
-    ///     Returns the hash code.
-    /// </summary>
-    /// <returns>
-    ///     A 32bit integer with sign. It has been constructed using the <see cref="Numerator" /> and the
-    ///     <see cref="Denominator" />.
-    /// </returns>
-    /// <filterpriority>2</filterpriority>
+    /// <summary>Returns the hash code.</summary>
+    /// <returns><inheritdoc cref="BigInteger.GetHashCode()"/></returns>
     public override int GetHashCode() {
         return FractionComparer.ValueEquality.GetHashCode(this);
     }

--- a/src/Fractions/Fraction.Equality.cs
+++ b/src/Fractions/Fraction.Equality.cs
@@ -1,4 +1,6 @@
-﻿namespace Fractions;
+﻿using System;
+
+namespace Fractions;
 
 public readonly partial struct Fraction {
     /// <summary>
@@ -8,11 +10,10 @@ public readonly partial struct Fraction {
     /// </summary>
     /// <param name="other">The fraction to compare with.</param>
     /// <returns><c>true</c> if both values are equivalent. (e.g. 2/4 is equivalent to 1/2. But 2/4 is not equivalent to -1/2)</returns>
+    [Obsolete("As of version 8.0.0, the equality of values is checked when Fraction.Equals(..) is called. Please use the .Equals(..) method.",
+        error: false)]
     public bool IsEquivalentTo(Fraction other) {
-        var a = Reduce();
-        var b = other.Reduce();
-
-        return a.Equals(b);
+        return Equals(other);
     }
 
     /// <summary>
@@ -29,7 +30,7 @@ public readonly partial struct Fraction {
     ///     <see cref="NaN" />.
     /// </returns>
     public bool Equals(Fraction other) {
-        return other.Denominator.Equals(Denominator) && other.Numerator.Equals(Numerator);
+        return FractionComparer.ValueEquality.Equals(this, other);
     }
 
     /// <summary>
@@ -58,8 +59,6 @@ public readonly partial struct Fraction {
     /// </returns>
     /// <filterpriority>2</filterpriority>
     public override int GetHashCode() {
-        unchecked {
-            return (Denominator.GetHashCode() * 397) ^ Numerator.GetHashCode();
-        }
+        return FractionComparer.ValueEquality.GetHashCode(this);
     }
 }

--- a/src/Fractions/Fraction.Math.cs
+++ b/src/Fractions/Fraction.Math.cs
@@ -139,7 +139,7 @@ public readonly partial struct Fraction {
         if (otherDenominator.IsZero) {
             return summand; // (+/-) Infinity
         }
-        
+
         //  normalizing the signs
         if (_normalizationNotApplied && thisDenominator.Sign == -1) {
             thisDenominator = -thisDenominator;
@@ -153,7 +153,6 @@ public readonly partial struct Fraction {
 
         // both values are non-zero
         if (_normalizationNotApplied || summand._normalizationNotApplied) {
-
             if (thisDenominator == otherDenominator) {
                 return new Fraction(true, thisNumerator + otherNumerator, thisDenominator);
             }
@@ -218,7 +217,7 @@ public readonly partial struct Fraction {
             if (gcd == otherDenominator) {
                 return ReduceSigned(thisNumerator + thisDenominator / gcd * otherNumerator, thisDenominator);
             }
-            
+
             var thisMultiplier = thisDenominator / gcd;
             var otherMultiplier = otherDenominator / gcd;
 
@@ -287,24 +286,24 @@ public readonly partial struct Fraction {
             reduceTerms(ref otherNumerator, ref thisDenominator);
 
             return new Fraction(true,
-                MultiplyTerms(thisNumerator, otherNumerator),
-                MultiplyTerms(thisDenominator, otherDenominator));
+                MultiplyTerms(ref thisNumerator, ref otherNumerator),
+                MultiplyTerms(ref thisDenominator, ref otherDenominator));
         }
 
         if (thisNumerator.IsZero || otherNumerator.IsZero) {
             return Zero;
         }
-            
+
         return ReduceSigned(
-            MultiplyTerms(thisNumerator, otherNumerator),
-            MultiplyTerms(thisDenominator, otherDenominator));
+            MultiplyTerms(ref thisNumerator, ref otherNumerator),
+            MultiplyTerms(ref thisDenominator, ref otherDenominator));
 
         static void reduceTerms(ref BigInteger numerator, ref BigInteger denominator) {
             if (numerator.IsOne || denominator.IsOne ||
                 numerator == BigInteger.MinusOne || denominator == BigInteger.MinusOne) {
                 return;
             }
-        
+
             var gcd = BigInteger.GreatestCommonDivisor(numerator, denominator);
             if (gcd.IsOne) {
                 return;
@@ -313,16 +312,6 @@ public readonly partial struct Fraction {
             numerator /= gcd;
             denominator /= gcd;
         }
-    }
-
-    private static BigInteger MultiplyTerms(BigInteger thisNumerator, BigInteger otherNumerator) {
-        if (thisNumerator.IsOne) {
-            return otherNumerator;
-        }
-
-        return otherNumerator.IsOne
-            ? thisNumerator
-            : thisNumerator * otherNumerator;
     }
 
     /// <summary>
@@ -355,8 +344,12 @@ public readonly partial struct Fraction {
         }
 
         if (_normalizationNotApplied || divisor._normalizationNotApplied) {
-            var numerator = thisNumerator.IsZero ? thisNumerator : MultiplyTerms(thisNumerator, otherDenominator);
-            var denominator = otherNumerator.IsZero ? otherNumerator : MultiplyTerms(thisDenominator, otherNumerator);
+            var numerator = thisNumerator.IsZero
+                ? thisNumerator
+                : MultiplyTerms(ref thisNumerator, ref otherDenominator);
+            var denominator = otherNumerator.IsZero
+                ? otherNumerator
+                : MultiplyTerms(ref thisDenominator, ref otherNumerator);
             return new Fraction(true, numerator, denominator);
         }
 
@@ -376,8 +369,8 @@ public readonly partial struct Fraction {
         }
 
         return ReduceSigned(
-            MultiplyTerms(thisNumerator, otherDenominator),
-            MultiplyTerms(thisDenominator, otherNumerator));
+            MultiplyTerms(ref thisNumerator, ref otherDenominator),
+            MultiplyTerms(ref thisDenominator, ref otherNumerator));
     }
 
     /// <summary>
@@ -443,14 +436,14 @@ public readonly partial struct Fraction {
         if (numerator.IsOne || denominator.IsOne || numerator == BigInteger.MinusOne) {
             return new Fraction(false, numerator, denominator);
         }
-        
+
         var gcd = BigInteger.GreatestCommonDivisor(numerator, denominator);
 
         return gcd.IsOne
             ? new Fraction(false, numerator, denominator)
             : new Fraction(false, numerator / gcd, denominator / gcd);
     }
-    
+
     /// <summary>
     /// Returns a fraction raised to the specified power.
     /// </summary>
@@ -506,5 +499,15 @@ public readonly partial struct Fraction {
         return fraction is { _normalizationNotApplied: false, Numerator.Sign: -1 }
             ? new Fraction(false, -fraction.Denominator, -fraction.Numerator)
             : new Fraction(fraction._normalizationNotApplied, fraction.Denominator, fraction.Numerator);
+    }
+
+    internal static BigInteger MultiplyTerms(ref readonly BigInteger a, ref readonly BigInteger b) {
+        if (a.IsOne) {
+            return b;
+        }
+
+        return b.IsOne
+            ? a
+            : a * b;
     }
 }

--- a/src/Fractions/Fraction.Math.cs
+++ b/src/Fractions/Fraction.Math.cs
@@ -343,12 +343,6 @@ public readonly partial struct Fraction {
         var thisNumerator = Numerator;
         var thisDenominator = Denominator;
 
-        if (_normalizationNotApplied || divisor._normalizationNotApplied) {
-            var numerator = thisNumerator.IsZero ? thisNumerator : MultiplyTerms(thisNumerator, otherDenominator);
-            var denominator = otherNumerator.IsZero ? otherNumerator : MultiplyTerms(thisDenominator, otherNumerator);
-            return new Fraction(true, numerator, denominator);
-        }
-
         if (thisDenominator.IsZero) {
             // `this` is NaN or Infinity
             return thisNumerator.Sign switch {
@@ -358,6 +352,12 @@ public readonly partial struct Fraction {
                 // NaN divided by a number
                 _ => NaN
             };
+        }
+
+        if (_normalizationNotApplied || divisor._normalizationNotApplied) {
+            var numerator = thisNumerator.IsZero ? thisNumerator : MultiplyTerms(thisNumerator, otherDenominator);
+            var denominator = otherNumerator.IsZero ? otherNumerator : MultiplyTerms(thisDenominator, otherNumerator);
+            return new Fraction(true, numerator, denominator);
         }
 
         switch (otherNumerator.Sign) {

--- a/src/Fractions/Fraction.cs
+++ b/src/Fractions/Fraction.cs
@@ -20,6 +20,15 @@ public readonly partial struct Fraction : IEquatable<Fraction>, IComparable, ICo
 #pragma warning restore IDE1006
 
     private readonly BigInteger? _denominator; 
+
+    /// <summary>
+    /// No normalization was performed when creating the fraction.
+    /// </summary>
+    /// <remarks>
+    /// If the value is <c>true</c>, we don't know whether it is a real or improper fraction.
+    /// The numerator and denominator do not necessarily have to be reduced to the lowest common divisor.
+    /// The signs may not be normalized. NaN and/or Infinity may not be normalized.
+    /// </remarks>
     private readonly bool _normalizationNotApplied;
 
     /// <summary>

--- a/src/Fractions/Fractions.csproj.DotSettings
+++ b/src/Fractions/Fractions.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=comparers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=equalitycomparers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/Fractions.Tests/Comparers/FractionStrictEqualityComparerSpecs/FractionStrictEqualityComparerSpecs.cs
+++ b/tests/Fractions.Tests/Comparers/FractionStrictEqualityComparerSpecs/FractionStrictEqualityComparerSpecs.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Fractions.Tests.Comparers.FractionStrictEqualityComparerSpecs;
+
+[TestFixture]
+public class When_two_fractions_are_checked_for_equality_of_value {
+    private readonly FractionComparer _sut = FractionComparer.StrictEquality;
+
+    private static IEnumerable<TestCaseData> NonNullTestCases {
+        get {
+            // positive
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(true);
+            yield return new TestCaseData(Fraction.One, Fraction.One).Returns(true);
+            yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(true);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.MinusOne).Returns(true);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(true);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2, normalize: false), new Fraction(1, 2)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, 4, normalize: false),
+                new Fraction(2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                new Fraction(2, -4, normalize: false)).Returns(true);
+
+            // double.NaN.Equals(double.NaN) == true
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(true);
+
+            // negative
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                new Fraction(-2, 4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(false);
+            yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(false);
+            yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(false);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(false);
+        }
+    }
+
+    [Test, TestCaseSource(nameof(NonNullTestCases))]
+    public bool Should_the_value_equality_test_be_as_expected(Fraction a, Fraction b) =>
+        _sut.Equals(a, b);
+
+    [Test, TestCaseSource(nameof(NonNullTestCases))]
+    public bool Should_the_comparision_of_the_HashCodes_be_as_expected(Fraction a, Fraction b) =>
+        _sut.GetHashCode(a) == _sut.GetHashCode(b);
+
+    [Test, TestCaseSource(nameof(NonNullTestCases))]
+    public bool Should_the_comparision_of_the_HashCodes_for_the_object_data_type_be_as_expected(object a, object b) =>
+        _sut.GetHashCode(a) == _sut.GetHashCode(b);
+
+    private static IEnumerable<TestCaseData> TestCasesWithNull {
+        get {
+            foreach (var testCase in NonNullTestCases) {
+                yield return testCase;
+            }
+
+            yield return new TestCaseData(null, null).Returns(true);
+
+            yield return new TestCaseData(Fraction.One, null).Returns(false);
+            yield return new TestCaseData(null, Fraction.One).Returns(false);
+
+            yield return new TestCaseData(Fraction.Zero, null).Returns(false);
+            yield return new TestCaseData(null, Fraction.Zero).Returns(false);
+        }
+    }
+
+    [Test, TestCaseSource(nameof(TestCasesWithNull))]
+    public bool Should_the_value_equality_test_of_type_object_be_as_expected(object a, object b) =>
+        _sut.Equals(a, b);
+}
+
+[TestFixture]
+public class When_the_hash_codes_of_two_fractions_are_checked {
+    private readonly FractionComparer _sut = FractionComparer.StrictEquality;
+
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            // positive
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(true);
+            yield return new TestCaseData(Fraction.One, Fraction.One).Returns(true);
+            yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(true);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.MinusOne).Returns(true);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(true);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, 4, normalize: false),
+                new Fraction(2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                new Fraction(2, -4, normalize: false)).Returns(true);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(true);
+
+            // negative
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                    new Fraction(-2, 4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(false);
+            yield return new TestCaseData(new Fraction(5), new Fraction(6)).Returns(false);
+            yield return new TestCaseData(new Fraction(100), new Fraction(10)).Returns(false);
+            yield return new TestCaseData(new Fraction(int.MaxValue), new Fraction(int.MinValue + 1)).Returns(false);
+            yield return new TestCaseData(new Fraction(double.MaxValue),
+                new Fraction(double.MinValue + double.Epsilon)).Returns(false);
+
+            yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(false);
+            yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(false);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(false);
+        }
+    }
+
+    [Test, TestCaseSource(nameof(TestCases))]
+    public bool Should_the_number_distribution_be_as_expected(Fraction a, Fraction b) =>
+        _sut.GetHashCode(a) == _sut.GetHashCode(b);
+}

--- a/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
+++ b/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Fractions.Tests.Comparers.FractionValueEqualityComparerSpecs;
+
+[TestFixture]
+public class When_two_fractions_are_checked_for_equality_of_value {
+    private readonly FractionComparer _sut = FractionComparer.ValueEquality;
+
+    private static IEnumerable<TestCaseData> FractionTypeTestCases {
+        get {
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(true);
+            yield return new TestCaseData(Fraction.One, Fraction.One).Returns(true);
+            yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(true);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.MinusOne).Returns(true);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(true);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, 4, normalize: false), new Fraction(2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(2, -4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(-2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(true);
+
+            yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(false);
+            yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(false);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(false);
+
+        }
+    }
+
+    [Test, TestCaseSource(nameof(FractionTypeTestCases))]
+    public bool Should_the_value_equality_test_be_as_expected(Fraction a, Fraction b) =>
+        _sut.Equals(a, b);
+
+    [Test, TestCaseSource(nameof(FractionTypeTestCases))]
+    public bool Should_the_comparision_of_the_HashCodes_be_as_expected(Fraction a, Fraction b) {
+        if (a.IsNaN || b.IsNaN) {
+            return false; // special case (NaN values are not considered equal)
+        }
+
+        return _sut.GetHashCode(a) == _sut.GetHashCode(b);
+    }
+
+    private static IEnumerable<TestCaseData> ObjectTypeTestCases {
+        get {
+            foreach (var testCase in FractionTypeTestCases) {
+                yield return testCase;
+            }
+
+            yield return new TestCaseData(null, null).Returns(true);
+
+            yield return new TestCaseData(Fraction.One, null).Returns(false);
+            yield return new TestCaseData(null, Fraction.One).Returns(false);
+
+            yield return new TestCaseData(Fraction.Zero, null).Returns(false);
+            yield return new TestCaseData(null, Fraction.Zero).Returns(false);
+        }
+    }
+
+    [Test, TestCaseSource(nameof(ObjectTypeTestCases))]
+    public bool Should_the_value_equality_test_of_type_object_be_as_expected(object a, object b) =>
+        _sut.Equals(a, b);
+
+    [Test, TestCaseSource(nameof(FractionTypeTestCases))]
+    public bool Should_the_comparision_of_the_HashCodes_for_the_object_data_type_be_as_expected(object a, object b) {
+        if (a is Fraction f1 && b is Fraction f2 && (f1.IsNaN || f2.IsNaN)) {
+            return false; // special case (NaN values are not considered equal)
+        }
+
+        // fake hash code if a or b is null.
+        return _sut.GetHashCode(a) == _sut.GetHashCode(b);
+    }
+}
+
+[TestFixture]
+public class When_the_hash_codes_of_two_fractions_are_checked {
+    private readonly FractionComparer _sut = FractionComparer.ValueEquality;
+
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(0);
+            yield return new TestCaseData(Fraction.One, Fraction.One).Returns(0);
+            yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(0);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.MinusOne).Returns(0);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(0);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(0);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(0);
+            yield return new TestCaseData(new Fraction(2, 4, normalize: false), new Fraction(2, 4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(2, -4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(-2, 4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(0);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(0);
+
+            yield return new TestCaseData(new Fraction(5), new Fraction(6)).Returns(-1);
+            yield return new TestCaseData(new Fraction(100), new Fraction(10)).Returns(1);
+            yield return new TestCaseData(new Fraction(int.MaxValue), new Fraction(int.MinValue + 1)).Returns(1);
+            yield return new TestCaseData(new Fraction(double.MaxValue), new Fraction(double.MinValue + double.Epsilon)).Returns(1);
+
+            yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(1);
+            yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(-1);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(1);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(-1);
+        }
+    }
+
+    [Test,TestCaseSource(nameof(TestCases))]
+    public int Should_the_number_distribution_be_as_expected(Fraction a, Fraction b) =>
+        _sut.GetHashCode(a).CompareTo(_sut.GetHashCode(b));
+}

--- a/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
+++ b/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
@@ -26,7 +26,7 @@ public class When_two_fractions_are_checked_for_equality_of_value {
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(true);
-
+            
             // double.NaN.Equals(double.NaN) == true
             yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(true); 
 
@@ -37,12 +37,374 @@ public class When_two_fractions_are_checked_for_equality_of_value {
             yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(false);
             yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(false);
             yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(false);
+            
+            // Any number with NaN
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.One, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN).Returns(false);
+            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN).Returns(false);
+            // Any number with PositiveInfinity
+            yield return new TestCaseData(Fraction.One, Fraction.PositiveInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.PositiveInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(42, 66, false), Fraction.PositiveInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(-42, 66, false), Fraction.PositiveInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(42, -66, false), Fraction.PositiveInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(-42, -66, false), Fraction.PositiveInfinity).Returns(false);
+            // Any number with NegativeInfinity
+            yield return new TestCaseData(Fraction.One, Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(42, 66, false), Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(-42, 66, false), Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(42, -66, false), Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(new Fraction(-42, -66, false), Fraction.NegativeInfinity).Returns(false);
         }
     }
 
     [Test, TestCaseSource(nameof(NonNullTestCases))]
     public bool Should_the_value_equality_test_be_as_expected(Fraction a, Fraction b) =>
         _sut.Equals(a, b);
+
+    private static IEnumerable<TestCaseData> DifferentSignsTestCases {
+        get {
+            
+            #region {positive/positive} and {positive/negative}
+
+            // {1/1} != {1/-10}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(1, -10, false)).Returns(false);
+            // {1/10} != {1/-1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(1, -1, false)).Returns(false);
+
+            #endregion
+
+            #region {positive/positive} and {negative/positive}
+
+            // {1/1} != {-1/10}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(-1, 10, false)).Returns(false);
+            // {1/10} != {-1/1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-1, 1, false)).Returns(false);
+
+            #endregion
+
+            #region {positive/negative} and {positive/positive}
+
+            // {1/-1} != {1/10}
+            yield return new TestCaseData(new Fraction(1, -1, false), new Fraction(1, 10, false)).Returns(false);
+            // {1/-10} != {1/1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(1, 1, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/positive} and {positive/positive}
+
+            // {-1/1} != {1/10}
+            yield return new TestCaseData(new Fraction(-1, 1, false), new Fraction(1, 10, false)).Returns(false);
+            // {-1/10} != {1/1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(1, 1, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/negative} and {negative/positive}
+
+            // {-1/-1} != {-1/10}
+            yield return new TestCaseData(new Fraction(-1, -1, false), new Fraction(-1, 10, false)).Returns(false);
+            // {-1/-10} != {-1/1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(-1, 1, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/negative} and {positive/negative}
+
+            // {-1/-1} != {1/-10}
+            yield return new TestCaseData(new Fraction(-1, -1, false), new Fraction(1, -10, false)).Returns(false);
+            // {-1/-10} != {1/-1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(1, -1, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/positive} and {negative/negative}
+
+            // {-1/1} != {-1/-10}
+            yield return new TestCaseData(new Fraction(-1, 1, false), new Fraction(-1, -10, false)).Returns(false);
+            // {-1/10} != {-1/-1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(-1, -1, false)).Returns(false);
+
+            #endregion
+
+            #region {positive/negative} and {negative/negative}
+
+            // {1/-1} != {-1/-10}
+            yield return new TestCaseData(new Fraction(1, -1, false), new Fraction(-1, -10, false)).Returns(false);
+            // {1/-10} != {-1/-1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(-1, -1, false)).Returns(false);
+
+            #endregion
+        }
+    }
+
+    [Test, TestCaseSource(nameof(DifferentSignsTestCases))]
+    public bool Fractions_with_different_signs_should_not_be_equal(Fraction a, Fraction b) =>
+        _sut.Equals(a, b);
+    
+    private static IEnumerable<TestCaseData> DifferentFractionsTestCases {
+        get {
+            #region {positive/positive} and {positive/positive}
+
+            // {1/2} < {2/2}
+            yield return new TestCaseData(new Fraction(1, 2, false), new Fraction(2, 2, false)).Returns(false);
+            // {11/10} > {1/1}
+            yield return new TestCaseData(new Fraction(11, 10, false), new Fraction(1, 1, false)).Returns(false);
+            // {10/10} > {1/2}
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(1, 2, false)).Returns(false);
+            // {10/10} < {2/1}
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(2, 1, false)).Returns(false);
+            // {1/10} < {1/1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(1, 1, false)).Returns(false);
+            // {10/100} < {2/10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(2, 10, false)).Returns(false);
+            // {7/4} > {3/2}
+            yield return new TestCaseData(new Fraction(7, 4, false), new Fraction(3, 2, false)).Returns(false);
+            // {6/5} < {3/2}
+            yield return new TestCaseData(new Fraction(6, 5, false), new Fraction(3, 2, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/negative} and {negative/negative}
+            
+            // {-1/-2} < {-2/-2}
+            yield return new TestCaseData(new Fraction(-1, -2, false), new Fraction(-2, -2, false)).Returns(false);
+            // {-1/-2} < {-10/-10}
+            yield return new TestCaseData(new Fraction(-1, -2, false), new Fraction(-10, -10, false)).Returns(false);
+            // {-1/-1} < {-11/-10}
+            yield return new TestCaseData(new Fraction(-1, -1, false), new Fraction(-11, -10, false)).Returns(false);
+            // {-10/-10} < {-2/-1}
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(-2, -1, false)).Returns(false);
+            // {-1/-10} < {-1/-1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(-1, -1, false)).Returns(false);
+            // {-10/-100} < {-2/-10}
+            yield return new TestCaseData(new Fraction(-10, -100, false), new Fraction(-2, -10, false)).Returns(false);
+            // {-7/-4} > {-3/-2}
+            yield return new TestCaseData(new Fraction(-7, -4, false), new Fraction(-3, -2, false)).Returns(false);
+            // {-6/-5} < {-3/-2}
+            yield return new TestCaseData(new Fraction(-6, -5, false), new Fraction(-3, -2, false)).Returns(false);
+
+            #endregion
+            
+            #region {positive/positive} and {negative/negative}
+            
+            // {1/2} < {-2/-2}
+            yield return new TestCaseData(new Fraction(1, 2, false), new Fraction(-2, -2, false)).Returns(false);
+            // {1/10} < {-11/-100}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-11, -100, false)).Returns(false);
+            // {1/1} > {-2/-10}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(-2, -10, false)).Returns(false);
+            // {1/1} > {-1/-2}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(-1, -2, false)).Returns(false);
+            // {2/1} > {-1/-2}
+            yield return new TestCaseData(new Fraction(2, 1, false), new Fraction(-1, -2, false)).Returns(false);
+            // {10/10} < {-2/-1} 
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(-2, -1, false)).Returns(false);
+            // {1/10} < {-1/-1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-1, -1, false)).Returns(false);
+            // {10/100} < {-2/-10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(-2, -10, false)).Returns(false);
+            // {7/4} > {-3/-2}
+            yield return new TestCaseData(new Fraction(7, 4, false), new Fraction(-3, -2, false)).Returns(false);
+            // {6/5} < {-3/-2}
+            yield return new TestCaseData(new Fraction(6, 5, false), new Fraction(-3, -2, false)).Returns(false);
+
+            #endregion
+            
+            #region {negative/negative} and {positive/positive}
+            
+            // {-1/-2} < {2/2}
+            yield return new TestCaseData(new Fraction(-1, -2, false), new Fraction(2, 2, false)).Returns(false);
+            // {-10/-10} < {2/1} 
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(2, 1, false)).Returns(false);
+            // {-1/-10} < {1/1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(1, 1, false)).Returns(false);
+            // {-10/-100} < {2/10}
+            yield return new TestCaseData(new Fraction(-10, -100, false), new Fraction(2, 10, false)).Returns(false);
+            // {-7/-4} > {3/2}
+            yield return new TestCaseData(new Fraction(-7, -4, false), new Fraction(3, 2, false)).Returns(false);
+            // {-6/-5} < {3/2}
+            yield return new TestCaseData(new Fraction(-6, -5, false), new Fraction(3, 2, false)).Returns(false);
+
+            #endregion
+            
+            #region {positive/negative} and {positive/negative}
+            
+            // {1/-2} > {2/-2}
+            yield return new TestCaseData(new Fraction(1, -2, false), new Fraction(2, -2, false)).Returns(false);
+            // {1/-10} > {11/-100}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(11, -100, false)).Returns(false);
+            // {10/-10} > {2/-1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(2, -1, false)).Returns(false);
+            // {1/-10} > {1/-1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(1, -1, false)).Returns(false);
+            // {10/-100} > {2/-10}
+            yield return new TestCaseData(new Fraction(10, -100, false), new Fraction(2, -10, false)).Returns(false);
+            // {7/-4} < {3/-2}
+            yield return new TestCaseData(new Fraction(7, -4, false), new Fraction(3, -2, false)).Returns(false);
+            // {6/-5} > {3/-2}
+            yield return new TestCaseData(new Fraction(6, -5, false), new Fraction(3, -2, false)).Returns(false);
+
+            #endregion
+            
+            #region {positive/negative} and {negative/positive}
+            
+            // {1/-2} > {-2/2}
+            yield return new TestCaseData(new Fraction(1, -2, false), new Fraction(-2, 2, false)).Returns(false);
+            // {10/-10} > {-2/1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(-2, 1, false)).Returns(false);
+            // {1/-10} > {-1/1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(-1, 1, false)).Returns(false);
+            // {10/-100} > {-2/10}
+            yield return new TestCaseData(new Fraction(10, -100, false), new Fraction(-2, 10, false)).Returns(false);
+            // {7/-4} > {-3/2}
+            yield return new TestCaseData(new Fraction(7, -4, false), new Fraction(-3, 2, false)).Returns(false);
+            // {6/-5} > {-3/2}
+            yield return new TestCaseData(new Fraction(6, -5, false), new Fraction(-3, 2, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/positive} and {positive/negative}
+            
+            // {-1/2} > {2/-2}
+            yield return new TestCaseData(new Fraction(-1, 2, false), new Fraction(2, -2, false)).Returns(false);
+            // {-1/1} > {2/-1} 
+            yield return new TestCaseData(new Fraction(-1, 1, false), new Fraction(2, -1, false)).Returns(false);
+            // {-1/2} > {2/-1} 
+            yield return new TestCaseData(new Fraction(-1, 2, false), new Fraction(2, -1, false)).Returns(false);
+            // {-2/1} > {3/-1} 
+            yield return new TestCaseData(new Fraction(-2, 1, false), new Fraction(3, -1, false)).Returns(false);
+            // {-11/10} < {1/-1} 
+            yield return new TestCaseData(new Fraction(-11, 10, false), new Fraction(1, -1, false)).Returns(false);
+            // {-10/10} > {2/-1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(2, -1, false)).Returns(false);
+            // {-1/10} > {1/-1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(1, -1, false)).Returns(false);
+            // {-10/100} > {2/-10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(2, -10, false)).Returns(false);
+            // {-7/4} > {3/-2}
+            yield return new TestCaseData(new Fraction(-7, 4, false), new Fraction(3, -2, false)).Returns(false);
+            // {-6/5} > {3/-2}
+            yield return new TestCaseData(new Fraction(-6, 5, false), new Fraction(3, -2, false)).Returns(false);
+
+            #endregion
+
+            #region {negative/positive} and {negative/positive}
+            
+            // {-1/2} > {-2/2}
+            yield return new TestCaseData(new Fraction(-1, 2, false), new Fraction(-2, 2, false)).Returns(false);
+            // {-11/10} < {-1/1} 
+            yield return new TestCaseData(new Fraction(-11, 10, false), new Fraction(-1, 1, false)).Returns(false);
+            // {-10/10} < {-1/2} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(-1, 2, false)).Returns(false);
+            // {-10/10} > {-2/1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(-2, 1, false)).Returns(false);
+            // {-1/10} > {-1/1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(-1, 1, false)).Returns(false);
+            // {-10/100} > {-2/10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(-2, 10, false)).Returns(false);
+            // {-7/4} > {-3/2}
+            yield return new TestCaseData(new Fraction(-7, 4, false), new Fraction(-3, 2, false)).Returns(false);
+            // {-6/5} > {-3/2}
+            yield return new TestCaseData(new Fraction(-6, 5, false), new Fraction(-3, 2, false)).Returns(false);
+
+            #endregion
+        }
+    }
+    
+    [Test, TestCaseSource(nameof(DifferentFractionsTestCases))]
+    public bool Different_Fractions_with_same_signs_should_not_be_equal(Fraction a, Fraction b) => _sut.Equals(a, b);
+    private static IEnumerable<TestCaseData> EquivalentFractionsTestCases {
+        get {
+            
+            #region {positive/positive} and {positive/positive}
+
+            // {10/10} == {1/1}
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(1, 1, false)).Returns(true);
+            // {10/100} == {1/10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(1, 10, false)).Returns(true);
+
+            #endregion
+
+            #region {negative/negative} and {negative/negative}
+
+            // {-10/-10} == {-1/-1}
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(-1, -1, false)).Returns(true);
+            // {-10/-100} == {-1/-10}
+            yield return new TestCaseData(new Fraction(-10, -100, false), new Fraction(-1, -10, false)).Returns(true);
+
+            #endregion
+            
+            #region {positive/positive} and {negative/negative}
+
+            // {10/10} == {-1/-1} 
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(-1, -1, false)).Returns(true);
+            // {1/10} == {-10/-100}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-10, -100, false)).Returns(true);
+            // {10/100} == {-1/-10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(-1, -10, false)).Returns(true);
+
+            #endregion
+            
+            #region {negative/negative} and {positive/positive}
+
+            // {-10/-10} == {1/1} 
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(1, 1, false)).Returns(true);
+            // {-1/-10} == {10/100}
+            yield return new TestCaseData(new Fraction(-1,- 10, false), new Fraction(10, 100, false)).Returns(true);
+
+            #endregion
+            
+            #region {positive/negative} and {positive/negative}
+
+            // {10/-10} == {1/-1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(1, -1, false)).Returns(true);
+            // {1/-10} == {10/-100}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(10, -100, false)).Returns(true);
+
+            #endregion
+            
+            #region {positive/negative} and {negative/positive}
+
+            // {10/-10} == {-1/1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(-1, 1, false)).Returns(true);
+            // {1/-10} == {-10/100}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(-10, 100, false)).Returns(true);
+
+            #endregion
+
+            #region {negative/positive} and {positive/negative}
+
+            // {-10/10} == {1/-1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(1, -1, false)).Returns(true);
+            // {-1/10} and {10/-100}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(10, -100, false)).Returns(true);
+            // {-10/100} == {1/-10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(1, -10, false)).Returns(true);
+
+            #endregion
+
+            #region {negative/positive} and {negative/positive}
+
+            // {-10/10} == {-1/1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(-1, 1, false)).Returns(true);
+            // {-10/100} == {-1/10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(-1, 10, false)).Returns(true);
+
+            #endregion
+        }
+    }
+    
+    [Test, TestCaseSource(nameof(EquivalentFractionsTestCases))]
+    public bool Equivalent_Fractions_should_be_equal(Fraction a, Fraction b) => _sut.Equals(a, b);
 
     [Test, TestCaseSource(nameof(NonNullTestCases))]
     public bool Should_the_comparision_of_the_HashCodes_be_as_expected(Fraction a, Fraction b) =>

--- a/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
+++ b/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
@@ -7,8 +7,9 @@ namespace Fractions.Tests.Comparers.FractionValueEqualityComparerSpecs;
 public class When_two_fractions_are_checked_for_equality_of_value {
     private readonly FractionComparer _sut = FractionComparer.ValueEquality;
 
-    private static IEnumerable<TestCaseData> FractionTypeTestCases {
+    private static IEnumerable<TestCaseData> NonNullTestCases {
         get {
+            // positive
             yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(true);
             yield return new TestCaseData(Fraction.One, Fraction.One).Returns(true);
             yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(true);
@@ -16,38 +17,44 @@ public class When_two_fractions_are_checked_for_equality_of_value {
             yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(true);
             yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(true);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(true);
-            yield return new TestCaseData(new Fraction(2, 4, normalize: false), new Fraction(2, 4, normalize: false)).Returns(true);
-            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(2, -4, normalize: false)).Returns(true);
-            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(-2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, 4, normalize: false),
+                    new Fraction(2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                    new Fraction(2, -4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                    new Fraction(-2, 4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(true);
 
+            // double.NaN.Equals(double.NaN) == true
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(true); 
+
+            // negative
             yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(false);
             yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(false);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(false);
             yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(false);
             yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(false);
-
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(false);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(false);
         }
     }
 
-    [Test, TestCaseSource(nameof(FractionTypeTestCases))]
+    [Test, TestCaseSource(nameof(NonNullTestCases))]
     public bool Should_the_value_equality_test_be_as_expected(Fraction a, Fraction b) =>
         _sut.Equals(a, b);
 
-    [Test, TestCaseSource(nameof(FractionTypeTestCases))]
-    public bool Should_the_comparision_of_the_HashCodes_be_as_expected(Fraction a, Fraction b) {
-        if (a.IsNaN || b.IsNaN) {
-            return false; // special case (NaN values are not considered equal)
-        }
+    [Test, TestCaseSource(nameof(NonNullTestCases))]
+    public bool Should_the_comparision_of_the_HashCodes_be_as_expected(Fraction a, Fraction b) =>
+        _sut.GetHashCode(a) == _sut.GetHashCode(b);
 
-        return _sut.GetHashCode(a) == _sut.GetHashCode(b);
-    }
+    [Test, TestCaseSource(nameof(NonNullTestCases))]
+    public bool Should_the_comparision_of_the_HashCodes_for_the_object_data_type_be_as_expected(object a, object b) =>
+        _sut.GetHashCode(a) == _sut.GetHashCode(b);
 
-    private static IEnumerable<TestCaseData> ObjectTypeTestCases {
+    private static IEnumerable<TestCaseData> TestCasesWithNull {
         get {
-            foreach (var testCase in FractionTypeTestCases) {
+            foreach (var testCase in NonNullTestCases) {
                 yield return testCase;
             }
 
@@ -61,19 +68,9 @@ public class When_two_fractions_are_checked_for_equality_of_value {
         }
     }
 
-    [Test, TestCaseSource(nameof(ObjectTypeTestCases))]
+    [Test, TestCaseSource(nameof(TestCasesWithNull))]
     public bool Should_the_value_equality_test_of_type_object_be_as_expected(object a, object b) =>
         _sut.Equals(a, b);
-
-    [Test, TestCaseSource(nameof(FractionTypeTestCases))]
-    public bool Should_the_comparision_of_the_HashCodes_for_the_object_data_type_be_as_expected(object a, object b) {
-        if (a is Fraction f1 && b is Fraction f2 && (f1.IsNaN || f2.IsNaN)) {
-            return false; // special case (NaN values are not considered equal)
-        }
-
-        // fake hash code if a or b is null.
-        return _sut.GetHashCode(a) == _sut.GetHashCode(b);
-    }
 }
 
 [TestFixture]
@@ -89,9 +86,12 @@ public class When_the_hash_codes_of_two_fractions_are_checked {
             yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(0);
             yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(0);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(0);
-            yield return new TestCaseData(new Fraction(2, 4, normalize: false), new Fraction(2, 4, normalize: false)).Returns(0);
-            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(2, -4, normalize: false)).Returns(0);
-            yield return new TestCaseData(new Fraction(2, -4, normalize: false), new Fraction(-2, 4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(2, 4, normalize: false),
+                    new Fraction(2, 4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                    new Fraction(2, -4, normalize: false)).Returns(0);
+            yield return new TestCaseData(new Fraction(2, -4, normalize: false),
+                    new Fraction(-2, 4, normalize: false)).Returns(0);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(0);
             yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(0);
             yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(0);
@@ -100,7 +100,8 @@ public class When_the_hash_codes_of_two_fractions_are_checked {
             yield return new TestCaseData(new Fraction(5), new Fraction(6)).Returns(-1);
             yield return new TestCaseData(new Fraction(100), new Fraction(10)).Returns(1);
             yield return new TestCaseData(new Fraction(int.MaxValue), new Fraction(int.MinValue + 1)).Returns(1);
-            yield return new TestCaseData(new Fraction(double.MaxValue), new Fraction(double.MinValue + double.Epsilon)).Returns(1);
+            yield return new TestCaseData(new Fraction(double.MaxValue),
+                    new Fraction(double.MinValue + double.Epsilon)).Returns(1);
 
             yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(1);
             yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(-1);
@@ -109,7 +110,7 @@ public class When_the_hash_codes_of_two_fractions_are_checked {
         }
     }
 
-    [Test,TestCaseSource(nameof(TestCases))]
+    [Test, TestCaseSource(nameof(TestCases))]
     public int Should_the_number_distribution_be_as_expected(Fraction a, Fraction b) =>
         _sut.GetHashCode(a).CompareTo(_sut.GetHashCode(b));
 }

--- a/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
+++ b/tests/Fractions.Tests/Comparers/FractionValueEqualityComparerSpecs/FractionValueEqualityComparerSpecs.cs
@@ -79,38 +79,38 @@ public class When_the_hash_codes_of_two_fractions_are_checked {
 
     private static IEnumerable<TestCaseData> TestCases {
         get {
-            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(0);
-            yield return new TestCaseData(Fraction.One, Fraction.One).Returns(0);
-            yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(0);
-            yield return new TestCaseData(Fraction.MinusOne, Fraction.MinusOne).Returns(0);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(0);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(0);
-            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(0);
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero).Returns(true);
+            yield return new TestCaseData(Fraction.One, Fraction.One).Returns(true);
+            yield return new TestCaseData(Fraction.Two, Fraction.Two).Returns(true);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.MinusOne).Returns(true);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(true);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(1, 2)).Returns(true);
             yield return new TestCaseData(new Fraction(2, 4, normalize: false),
-                    new Fraction(2, 4, normalize: false)).Returns(0);
+                    new Fraction(2, 4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(2, -4, normalize: false),
-                    new Fraction(2, -4, normalize: false)).Returns(0);
+                    new Fraction(2, -4, normalize: false)).Returns(true);
             yield return new TestCaseData(new Fraction(2, -4, normalize: false),
-                    new Fraction(-2, 4, normalize: false)).Returns(0);
-            yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(0);
-            yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(0);
-            yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(0);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(0);
+                    new Fraction(-2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(1, 2), new Fraction(-2, -4, normalize: false)).Returns(true);
+            yield return new TestCaseData(new Fraction(-1, 2), new Fraction(-2, 4, normalize: false)).Returns(true);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(true);
 
-            yield return new TestCaseData(new Fraction(5), new Fraction(6)).Returns(-1);
-            yield return new TestCaseData(new Fraction(100), new Fraction(10)).Returns(1);
-            yield return new TestCaseData(new Fraction(int.MaxValue), new Fraction(int.MinValue + 1)).Returns(1);
+            yield return new TestCaseData(new Fraction(5), new Fraction(6)).Returns(false);
+            yield return new TestCaseData(new Fraction(100), new Fraction(10)).Returns(false);
+            yield return new TestCaseData(new Fraction(int.MaxValue), new Fraction(int.MinValue + 1)).Returns(false);
             yield return new TestCaseData(new Fraction(double.MaxValue),
-                    new Fraction(double.MinValue + double.Epsilon)).Returns(1);
+                    new Fraction(double.MinValue + double.Epsilon)).Returns(false);
 
-            yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(1);
-            yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(-1);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(1);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(-1);
+            yield return new TestCaseData(Fraction.Zero, Fraction.One).Returns(false);
+            yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(false);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity).Returns(false);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity).Returns(false);
         }
     }
 
     [Test, TestCaseSource(nameof(TestCases))]
-    public int Should_the_number_distribution_be_as_expected(Fraction a, Fraction b) =>
-        _sut.GetHashCode(a).CompareTo(_sut.GetHashCode(b));
+    public bool Should_the_number_distribution_be_as_expected(Fraction a, Fraction b) =>
+        _sut.GetHashCode(a) == _sut.GetHashCode(b);
 }

--- a/tests/Fractions.Tests/FractionSpecs/Abs/Method_Abs.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Abs/Method_Abs.cs
@@ -30,6 +30,6 @@ public class When_the_Abs_function_is_called : Spec {
 
     [Test]
     public void The_absolute_value_of_NaN_is_NaN() {
-        Fraction.NaN.Abs().Should().Be(Fraction.NaN);
+        Fraction.NaN.Abs().IsNaN.Should().BeTrue();
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Add/Method_Add.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Add/Method_Add.cs
@@ -10,73 +10,54 @@ public class When_the_user_adds_two_fractions : Spec {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // rational numbers
-            yield return new TestCaseData(Fraction.Zero, Fraction.Zero)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(1L, 5L), new Fraction(1L, 4L))
-                .Returns(new Fraction(9L, 20L));
-            yield return new TestCaseData(new Fraction(1L, 5L), Fraction.Zero)
-                .Returns(new Fraction(1L, 5L));
-            yield return new TestCaseData(Fraction.Zero, new Fraction(1L, 5L))
-                .Returns(new Fraction(1L, 5L));
-            yield return new TestCaseData(new Fraction(1, long.MaxValue), new Fraction(1, long.MaxValue - 1))
-                .Returns(new Fraction(
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(1L, 5L), new Fraction(1L, 4L), new Fraction(9L, 20L));
+            yield return new TestCaseData(new Fraction(1L, 5L), Fraction.Zero, new Fraction(1L, 5L));
+            yield return new TestCaseData(Fraction.Zero, new Fraction(1L, 5L), new Fraction(1L, 5L));
+            yield return new TestCaseData(new Fraction(1, long.MaxValue), new Fraction(1, long.MaxValue - 1),
+                new Fraction(
                     BigInteger.Parse("18446744073709551613"),
                     BigInteger.Parse("85070591730234615838173535747377725442")
                 ));
 
             // positive infinity
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN)
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity,
+                Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false),
+                Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN, Fraction.NaN);
 
             // negative infinity
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN)
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity,
+                Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false),
+                Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 0, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN, Fraction.NaN);
 
             // NaN
-            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.One)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.Zero)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN)
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.One, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction It_should_return_the_expected_result(Fraction a, Fraction b) => a.Add(b);
+    public void It_should_return_the_expected_result(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Add(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
+    }
 }

--- a/tests/Fractions.Tests/FractionSpecs/CompareTo/Method_CompareTo.cs
+++ b/tests/Fractions.Tests/FractionSpecs/CompareTo/Method_CompareTo.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
+using FluentAssertions;
 using NUnit.Framework;
 using Tests.Fractions;
 
@@ -103,6 +106,20 @@ public class When_comparing_two_fractions : Spec {
             yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN).Returns(1);
             yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN).Returns(1);
             yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN).Returns(1);
+            // Any number with PositiveInfinity
+            yield return new TestCaseData(Fraction.One, Fraction.PositiveInfinity).Returns(-1);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.PositiveInfinity).Returns(-1);
+            yield return new TestCaseData(new Fraction(42, 66, false), Fraction.PositiveInfinity).Returns(-1);
+            yield return new TestCaseData(new Fraction(-42, 66, false), Fraction.PositiveInfinity).Returns(-1);
+            yield return new TestCaseData(new Fraction(42, -66, false), Fraction.PositiveInfinity).Returns(-1);
+            yield return new TestCaseData(new Fraction(-42, -66, false), Fraction.PositiveInfinity).Returns(-1);
+            // Any number with NegativeInfinity
+            yield return new TestCaseData(Fraction.One, Fraction.NegativeInfinity).Returns(1);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.NegativeInfinity).Returns(1);
+            yield return new TestCaseData(new Fraction(42, 66, false), Fraction.NegativeInfinity).Returns(1);
+            yield return new TestCaseData(new Fraction(-42, 66, false), Fraction.NegativeInfinity).Returns(1);
+            yield return new TestCaseData(new Fraction(42, -66, false), Fraction.NegativeInfinity).Returns(1);
+            yield return new TestCaseData(new Fraction(-42, -66, false), Fraction.NegativeInfinity).Returns(1);
         }
     }
 
@@ -110,5 +127,384 @@ public class When_comparing_two_fractions : Spec {
     [TestCaseSource(nameof(TestCases))]
     public int The_CompareTo_method_should_return_the_expected_result(Fraction a, Fraction b) {
         return a.CompareTo(b);
+    }
+
+    
+    private static IEnumerable<TestCaseData> DifferentSignsTestCases {
+        get {
+            
+            #region {positive/positive} and {positive/negative}
+
+            // {1/1} != {1/-10}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(1, -10, false)).Returns(1);
+            // {1/10} != {1/-1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(1, -1, false)).Returns(1);
+
+            #endregion
+
+            #region {positive/positive} and {negative/positive}
+
+            // {1/1} != {-1/10}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(-1, 10, false)).Returns(1);
+            // {1/10} != {-1/1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-1, 1, false)).Returns(1);
+
+            #endregion
+
+            #region {positive/negative} and {positive/positive}
+
+            // {1/-1} != {1/10}
+            yield return new TestCaseData(new Fraction(1, -1, false), new Fraction(1, 10, false)).Returns(-1);
+            // {1/-10} != {1/1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(1, 1, false)).Returns(-1);
+
+            #endregion
+
+            #region {negative/positive} and {positive/positive}
+
+            // {-1/1} != {1/10}
+            yield return new TestCaseData(new Fraction(-1, 1, false), new Fraction(1, 10, false)).Returns(-1);
+            // {-1/10} != {1/1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(1, 1, false)).Returns(-1);
+
+            #endregion
+
+            #region {negative/negative} and {negative/positive}
+
+            // {-1/-1} != {-1/10}
+            yield return new TestCaseData(new Fraction(-1, -1, false), new Fraction(-1, 10, false)).Returns(1);
+            // {-1/-10} != {-1/1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(-1, 1, false)).Returns(1);
+
+            #endregion
+
+            #region {negative/negative} and {positive/negative}
+
+            // {-1/-1} != {1/-10}
+            yield return new TestCaseData(new Fraction(-1, -1, false), new Fraction(1, -10, false)).Returns(1);
+            // {-1/-10} != {1/-1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(1, -1, false)).Returns(1);
+
+            #endregion
+
+            #region {negative/positive} and {negative/negative}
+
+            // {-1/1} != {-1/-10}
+            yield return new TestCaseData(new Fraction(-1, 1, false), new Fraction(-1, -10, false)).Returns(-1);
+            // {-1/10} != {-1/-1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(-1, -1, false)).Returns(-1);
+
+            #endregion
+
+            #region {positive/negative} and {negative/negative}
+
+            // {1/-1} != {-1/-10}
+            yield return new TestCaseData(new Fraction(1, -1, false), new Fraction(-1, -10, false)).Returns(-1);
+            // {1/-10} != {-1/-1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(-1, -1, false)).Returns(-1);
+
+            #endregion
+        }
+    }
+    
+    [Test, TestCaseSource(nameof(DifferentSignsTestCases))]
+    public int Fractions_with_different_signs_should_return_non_zero(Fraction a, Fraction b) => a.CompareTo(b);
+
+    
+    private static IEnumerable<TestCaseData> EqualFractionsTestCases {
+        get {
+            #region {positive/positive} and {positive/positive}
+
+            // {10/10} == {1/1}
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(1, 1, false)).Returns(0);
+            // {10/100} == {1/10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(1, 10, false)).Returns(0);
+
+            #endregion
+
+            #region {negative/negative} and {negative/negative}
+
+            // {-10/-10} == {-1/-1}
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(-1, -1, false)).Returns(0);
+            // {-10/-100} == {-1/-10}
+            yield return new TestCaseData(new Fraction(-10, -100, false), new Fraction(-1, -10, false)).Returns(0);
+
+            #endregion
+            
+            #region {positive/positive} and {negative/negative}
+
+            // {10/10} == {-1/-1} 
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(-1, -1, false)).Returns(0);
+            // {1/10} == {-10/-100}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-10, -100, false)).Returns(0);
+            // {10/100} == {-1/-10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(-1, -10, false)).Returns(0);
+
+            #endregion
+            
+            #region {negative/negative} and {positive/positive}
+
+            // {-10/-10} == {1/1} 
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(1, 1, false)).Returns(0);
+            // {-1/-10} == {10/100}
+            yield return new TestCaseData(new Fraction(-1,- 10, false), new Fraction(10, 100, false)).Returns(0);
+
+            #endregion
+            
+            #region {positive/negative} and {positive/negative}
+
+            // {10/-10} == {1/-1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(1, -1, false)).Returns(0);
+            // {1/-10} == {10/-100}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(10, -100, false)).Returns(0);
+
+            #endregion
+            
+            #region {positive/negative} and {negative/positive}
+
+            // {10/-10} == {-1/1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(-1, 1, false)).Returns(0);
+            // {1/-10} == {-10/100}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(-10, 100, false)).Returns(0);
+
+            #endregion
+
+            #region {negative/positive} and {positive/negative}
+
+            // {-10/10} == {1/-1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(1, -1, false)).Returns(0);
+            // {-1/10} and {10/-100}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(10, -100, false)).Returns(0);
+            // {-10/100} == {1/-10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(1, -10, false)).Returns(0);
+
+            #endregion
+
+            #region {negative/positive} and {negative/positive}
+
+            // {-10/10} == {-1/1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(-1, 1, false)).Returns(0);
+            // {-10/100} == {-1/10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(-1, 10, false)).Returns(0);
+
+            #endregion
+        }
+    }
+    
+    [Test, TestCaseSource(nameof(EqualFractionsTestCases))]
+    public int Equal_fractions_should_return_zero(Fraction a, Fraction b) => a.CompareTo(b);
+    
+    
+    private static IEnumerable<TestCaseData> DifferentFractionsTestCases {
+        get {
+            #region {positive/positive} and {positive/positive}
+
+            // {1/2} < {2/2}
+            yield return new TestCaseData(new Fraction(1, 2, false), new Fraction(2, 2, false)).Returns(-1);
+            // {11/10} > {1/1}
+            yield return new TestCaseData(new Fraction(11, 10, false), new Fraction(1, 1, false)).Returns(1);
+            // {10/10} > {1/2}
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(1, 2, false)).Returns(1);
+            // {10/10} < {2/1}
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(2, 1, false)).Returns(-1);
+            // {1/10} < {1/1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(1, 1, false)).Returns(-1);
+            // {10/100} < {2/10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(2, 10, false)).Returns(-1);
+            // {7/4} > {3/2}
+            yield return new TestCaseData(new Fraction(7, 4, false), new Fraction(3, 2, false)).Returns(1);
+            // {6/5} < {3/2}
+            yield return new TestCaseData(new Fraction(6, 5, false), new Fraction(3, 2, false)).Returns(-1);
+
+            #endregion
+
+            #region {negative/negative} and {negative/negative}
+
+            // {-1/-2} < {-2/-2}
+            yield return new TestCaseData(new Fraction(-1, -2, false), new Fraction(-2, -2, false)).Returns(-1);
+            // {-1/-2} < {-10/-10}
+            yield return new TestCaseData(new Fraction(-1, -2, false), new Fraction(-10, -10, false)).Returns(-1);
+            // {-1/-1} < {-11/-10}
+            yield return new TestCaseData(new Fraction(-1, -1, false), new Fraction(-11, -10, false)).Returns(-1);
+            // {-10/-10} < {-2/-1}
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(-2, -1, false)).Returns(-1);
+            // {-1/-10} < {-1/-1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(-1, -1, false)).Returns(-1);
+            // {-10/-100} < {-2/-10}
+            yield return new TestCaseData(new Fraction(-10, -100, false), new Fraction(-2, -10, false)).Returns(-1);
+            // {-7/-4} > {-3/-2}
+            yield return new TestCaseData(new Fraction(-7, -4, false), new Fraction(-3, -2, false)).Returns(1);
+            // {-6/-5} < {-3/-2}
+            yield return new TestCaseData(new Fraction(-6, -5, false), new Fraction(-3, -2, false)).Returns(-1);
+
+            #endregion
+            
+            #region {positive/positive} and {negative/negative}
+
+            // {1/2} < {-2/-2}
+            yield return new TestCaseData(new Fraction(1, 2, false), new Fraction(-2, -2, false)).Returns(-1);
+            // {1/10} < {-11/-100}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-11, -100, false)).Returns(-1);
+            // {1/1} > {-2/-10}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(-2, -10, false)).Returns(1);
+            // {1/1} > {-1/-2}
+            yield return new TestCaseData(new Fraction(1, 1, false), new Fraction(-1, -2, false)).Returns(1);
+            // {2/1} > {-1/-2}
+            yield return new TestCaseData(new Fraction(2, 1, false), new Fraction(-1, -2, false)).Returns(1);
+            // {10/10} < {-2/-1} 
+            yield return new TestCaseData(new Fraction(10, 10, false), new Fraction(-2, -1, false)).Returns(-1);
+            // {1/10} < {-1/-1}
+            yield return new TestCaseData(new Fraction(1, 10, false), new Fraction(-1, -1, false)).Returns(-1);
+            // {10/100} < {-2/-10}
+            yield return new TestCaseData(new Fraction(10, 100, false), new Fraction(-2, -10, false)).Returns(-1);
+            // {7/4} > {-3/-2}
+            yield return new TestCaseData(new Fraction(7, 4, false), new Fraction(-3, -2, false)).Returns(1);
+            // {6/5} < {-3/-2}
+            yield return new TestCaseData(new Fraction(6, 5, false), new Fraction(-3, -2, false)).Returns(-1);
+
+            #endregion
+            
+            #region {negative/negative} and {positive/positive}
+            
+            // {-1/-2} < {2/2}
+            yield return new TestCaseData(new Fraction(-1, -2, false), new Fraction(2, 2, false)).Returns(-1);
+            // {-10/-10} < {2/1} 
+            yield return new TestCaseData(new Fraction(-10, -10, false), new Fraction(2, 1, false)).Returns(-1);
+            // {-1/-10} < {1/1}
+            yield return new TestCaseData(new Fraction(-1, -10, false), new Fraction(1, 1, false)).Returns(-1);
+            // {-10/-100} < {2/10}
+            yield return new TestCaseData(new Fraction(-10, -100, false), new Fraction(2, 10, false)).Returns(-1);
+            // {-7/-4} > {3/2}
+            yield return new TestCaseData(new Fraction(-7, -4, false), new Fraction(3, 2, false)).Returns(1);
+            // {-6/-5} < {3/2}
+            yield return new TestCaseData(new Fraction(-6, -5, false), new Fraction(3, 2, false)).Returns(-1);
+
+            #endregion
+            
+            #region {positive/negative} and {positive/negative}
+
+            // {1/-2} > {2/-2}
+            yield return new TestCaseData(new Fraction(1, -2, false), new Fraction(2, -2, false)).Returns(1);
+            // {1/-10} > {11/-100}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(11, -100, false)).Returns(1);
+            // {10/-10} > {2/-1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(2, -1, false)).Returns(1);
+            // {1/-10} > {1/-1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(1, -1, false)).Returns(1);
+            // {10/-100} > {2/-10}
+            yield return new TestCaseData(new Fraction(10, -100, false), new Fraction(2, -10, false)).Returns(1);
+            // {7/-4} < {3/-2}
+            yield return new TestCaseData(new Fraction(7, -4, false), new Fraction(3, -2, false)).Returns(-1);
+            // {6/-5} > {3/-2}
+            yield return new TestCaseData(new Fraction(6, -5, false), new Fraction(3, -2, false)).Returns(1);
+
+            #endregion
+            
+            #region {positive/negative} and {negative/positive}
+
+            // {1/-2} > {-2/2}
+            yield return new TestCaseData(new Fraction(1, -2, false), new Fraction(-2, 2, false)).Returns(1);
+            // {10/-10} > {-2/1} 
+            yield return new TestCaseData(new Fraction(10, -10, false), new Fraction(-2, 1, false)).Returns(1);
+            // {1/-10} > {-1/1}
+            yield return new TestCaseData(new Fraction(1, -10, false), new Fraction(-1, 1, false)).Returns(1);
+            // {10/-100} > {-2/10}
+            yield return new TestCaseData(new Fraction(10, -100, false), new Fraction(-2, 10, false)).Returns(1);
+            // {7/-4} > {-3/2}
+            yield return new TestCaseData(new Fraction(7, -4, false), new Fraction(-3, 2, false)).Returns(-1);
+            // {6/-5} > {-3/2}
+            yield return new TestCaseData(new Fraction(6, -5, false), new Fraction(-3, 2, false)).Returns(1);
+
+            #endregion
+
+            #region {negative/positive} and {positive/negative}
+
+            // {-1/2} > {2/-2}
+            yield return new TestCaseData(new Fraction(-1, 2, false), new Fraction(2, -2, false)).Returns(1);
+            // {-1/1} > {2/-1} 
+            yield return new TestCaseData(new Fraction(-1, 1, false), new Fraction(2, -1, false)).Returns(1);
+            // {-1/2} > {2/-1} 
+            yield return new TestCaseData(new Fraction(-1, 2, false), new Fraction(2, -1, false)).Returns(1);
+            // {-2/1} > {3/-1} 
+            yield return new TestCaseData(new Fraction(-2, 1, false), new Fraction(3, -1, false)).Returns(1);
+            // {-11/10} < {1/-1} 
+            yield return new TestCaseData(new Fraction(-11, 10, false), new Fraction(1, -1, false)).Returns(-1);
+            // {-10/10} > {2/-1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(2, -1, false)).Returns(1);
+            // {-1/10} > {1/-1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(1, -1, false)).Returns(1);
+            // {-10/100} > {2/-10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(2, -10, false)).Returns(1);
+            // {-7/4} > {3/-2}
+            yield return new TestCaseData(new Fraction(-7, 4, false), new Fraction(3, -2, false)).Returns(-1);
+            // {-6/5} > {3/-2}
+            yield return new TestCaseData(new Fraction(-6, 5, false), new Fraction(3, -2, false)).Returns(1);
+
+            #endregion
+
+            #region {negative/positive} and {negative/positive}
+
+            // {-1/2} > {-2/2}
+            yield return new TestCaseData(new Fraction(-1, 2, false), new Fraction(-2, 2, false)).Returns(1);
+            // {-11/10} < {-1/1} 
+            yield return new TestCaseData(new Fraction(-11, 10, false), new Fraction(-1, 1, false)).Returns(-1);
+            // {-10/10} < {-1/2} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(-1, 2, false)).Returns(-1);
+            // {-10/10} > {-2/1} 
+            yield return new TestCaseData(new Fraction(-10, 10, false), new Fraction(-2, 1, false)).Returns(1);
+            // {-1/10} > {-1/1}
+            yield return new TestCaseData(new Fraction(-1, 10, false), new Fraction(-1, 1, false)).Returns(1);
+            // {-10/100} > {-2/10}
+            yield return new TestCaseData(new Fraction(-10, 100, false), new Fraction(-2, 10, false)).Returns(1);
+            // {-7/4} > {-3/2}
+            yield return new TestCaseData(new Fraction(-7, 4, false), new Fraction(-3, 2, false)).Returns(-1);
+            // {-6/5} > {-3/2}
+            yield return new TestCaseData(new Fraction(-6, 5, false), new Fraction(-3, 2, false)).Returns(1);
+
+            #endregion
+        }
+    }
+    
+    [Test, TestCaseSource(nameof(DifferentFractionsTestCases))]
+    public int Different_Fractions_with_same_signs_should_return_non_zero(Fraction a, Fraction b) => a.CompareTo(b);
+
+    public static IEnumerable<Fraction> FractionsToSort => [
+        Fraction.Zero,
+        Fraction.One,
+        10,
+        new Fraction(1, 10),
+        new Fraction(0.135m),
+        new Fraction(-0.135m),
+        new Fraction(decimal.MaxValue),
+        new Fraction(decimal.MinValue),
+        new Fraction(BigInteger.Pow(-10, 37)),
+        new Fraction(1, BigInteger.Pow(10, 12)),
+        new Fraction(42, 66, false),
+        new Fraction(36, 96, false),
+        new Fraction(42, -96, false),
+        new Fraction(-42, -96, false),
+        new Fraction(-42, 96, false),
+        Fraction.FromDouble(Math.PI),
+        Fraction.FromDouble(-Math.PI),
+        Fraction.NaN,
+        Fraction.PositiveInfinity,
+        Fraction.NegativeInfinity
+    ];
+
+
+    [Test]
+    public void Should_sort_fractions_in_expected_order() {
+        // Arrange
+        var result = FractionsToSort.OrderBy(fraction => fraction).ToArray();
+        // Assert
+        result.Should().BeInAscendingOrder((a, b) => a.ToDouble().CompareTo(b.ToDouble()));
+    }
+
+    [Test]
+    public void Should_sort_fractions_in_expected_descending_order() {
+        // Act
+        var result = FractionsToSort.OrderByDescending(fraction => fraction).ToArray();
+        // Assert
+        result.Should().BeInDescendingOrder((a, b) => a.ToDouble().CompareTo(b.ToDouble()));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/CompareTo/Method_CompareTo.cs
+++ b/tests/Fractions.Tests/FractionSpecs/CompareTo/Method_CompareTo.cs
@@ -17,6 +17,13 @@ public class When_comparing_two_fractions : Spec {
             yield return new TestCaseData(new Fraction(1, 10), new Fraction(10, 100, false)).Returns(0);
             yield return new TestCaseData(new Fraction(1, 10), new Fraction(-10, -100, false)).Returns(0);
             yield return new TestCaseData(new Fraction(-100, -1000, false), new Fraction(-10, -100, false)).Returns(0);
+            yield return new TestCaseData(new Fraction(0.2m), new Fraction(-2, -10, false)).Returns(0);
+            yield return new TestCaseData(new Fraction(-2, -10, false), new Fraction(0.2m)).Returns(0);
+
+            yield return new TestCaseData(new Fraction(0.1m), new Fraction(-2, -10, false)).Returns(-1);
+            yield return new TestCaseData(new Fraction(0.3m), new Fraction(-2, -10, false)).Returns(1);
+            yield return new TestCaseData(new Fraction(-2, -10, false), new Fraction(0.1m)).Returns(1);
+            yield return new TestCaseData(new Fraction(-2, -10, false), new Fraction(0.3m)).Returns(-1);
             // two negative numbers
             yield return new TestCaseData(new Fraction(-5), new Fraction(-4)).Returns(-1);
             yield return new TestCaseData(new Fraction(-4), new Fraction(-5)).Returns(1);

--- a/tests/Fractions.Tests/FractionSpecs/ConvertTo/Method_ConvertTo.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ConvertTo/Method_ConvertTo.cs
@@ -62,23 +62,8 @@ public class When_comparing_1_quarter_with_2_eighths : Spec {
     }
 
     [Test]
-    // German: Das Ergebnis sollte gleich 0 sein
     public void The_result_should_be_0() {
         _a.CompareTo(_b)
             .Should().Be(0);
-    }
-
-    [Test]
-    // German: Diese sollten nicht als vollständig identisch erachtet werden
-    public void These_should_not_be_considered_identical() {
-        _a.Equals(_b)
-            .Should().BeFalse();
-    }
-
-    [Test]
-    // German: Diese sollten als Wertgleich bzw. äquivalent erachtet werden
-    public void These_should_be_considered_equivalent() {
-        _a.IsEquivalentTo(_b)
-            .Should().BeTrue();
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Divide/Method_Divide.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Divide/Method_Divide.cs
@@ -247,36 +247,37 @@ public class When_dividing_with_NaN {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // NaN with NaN
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN, Fraction.NaN);
             // NaN with any number
-            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(5, 4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, -5, false)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.One).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(4, 5)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, 4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-4, 5)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(5, -5, false)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(5, 4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, -5, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.One, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(4, 5), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, 4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-4, 5), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(5, -5, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity, Fraction.NaN);
             // Any number with NaN
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.One, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.One, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_is_always_NaN(Fraction a, Fraction b) {
-        return a.Divide(b);
+    public void The_result_is_always_NaN(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Divide(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 
@@ -285,63 +286,42 @@ public class When_dividing_with_infinity {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // positive infinity with positive infinity
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false), Fraction.NaN);
 
             // positive infinity with any other number
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 4))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4, 5))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 4))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4, 5))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 4), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4, 5), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 4), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4, 5), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false), Fraction.NaN);
 
             // negative infinity with negative infinity
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false), Fraction.NaN);
 
             // negative infinity with any other number
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 4))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4, 5))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 4))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4, 5))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 4), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4, 5), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 4), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4, 5), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false), Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_is_always_NaN_or_Infinity(Fraction a, Fraction b) {
-        return a.Divide(b);
+    public void The_result_is_always_NaN_or_Infinity(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Divide(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 

--- a/tests/Fractions.Tests/FractionSpecs/Divide/Method_Divide.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Divide/Method_Divide.cs
@@ -17,7 +17,7 @@ public class When_dividing_0_by_0 : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 
@@ -355,7 +355,7 @@ public class When_dividing_1_by_NaN : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 
@@ -369,7 +369,7 @@ public class When_dividing_minus_1_by_NaN : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 
@@ -383,7 +383,7 @@ public class When_dividing_NaN_by_1 : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 
@@ -397,7 +397,7 @@ public class When_dividing_NaN_by_minus_1 : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 
@@ -411,7 +411,7 @@ public class When_dividing_NaN_by_NaN : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 

--- a/tests/Fractions.Tests/FractionSpecs/FromDouble/Method_FromDouble.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDouble/Method_FromDouble.cs
@@ -18,7 +18,7 @@ public class When_a_fraction_is_created_from_a_NaN_double : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 

--- a/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
@@ -18,7 +18,7 @@ public class When_a_fraction_is_created_based_on_a_NaN_double : Spec {
 
     [Test]
     public void The_result_should_be_NaN() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 

--- a/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
@@ -1296,9 +1296,9 @@ public class When_creating_a_fraction_from_the_string_0_over_10_without_normaliz
         Fraction.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, false, out var result).Should()
             .BeTrue();
         result.IsZero.Should().BeTrue(); // this is still considered "a zero"
-        result.Should().NotBe(Fraction.Zero); // however it isn't strictly equal to the Zero
-        result.Should().Be(new Fraction(0, 10, false)); // rather it's a non-normalized version
-        result.Equals(Fraction.Zero).Should().BeTrue(); // which can be reduced to Zero
+        ((object)result).Should().NotBe(Fraction.Zero, StrictTestComparer.Instance); // however it isn't strictly equal to the Zero
+        ((object)result).Should().Be(new Fraction(0, 10, false), StrictTestComparer.Instance); // rather it's a non-normalized version
+        result.Equals(Fraction.Zero).Should().BeTrue(); // Should be equal to Zero
     }
 }
 
@@ -1318,8 +1318,8 @@ public class When_creating_a_fraction_from_the_string_0_over_minus_10_without_no
         [Values("0 /-10", "0 / -10")] string value) {
         var result = Fraction.FromString(value, NumberStyles.Any, CultureInfo.InvariantCulture, false);
         result.IsZero.Should().BeTrue(); // this is still considered "a zero"
-        result.Should().NotBe(Fraction.Zero); // however it isn't strictly equal to the Zero
-        result.Should().Be(new Fraction(0, -10, false)); // rather it's a non-normalized version
+        ((object)result).Should().NotBe(Fraction.Zero, StrictTestComparer.Instance); // however it isn't strictly equal to the Zero
+        ((object)result).Should().Be(new Fraction(0, -10, false), StrictTestComparer.Instance); // rather it's a non-normalized version
         result.Equals(Fraction.Zero).Should().BeTrue(); // which can be reduced to Zero
     }
 }
@@ -1349,9 +1349,9 @@ public class When_creating_a_fraction_from_the_string_10_over_0_without_normaliz
         [Values("10/0", "10 /-0", "10 / -0")] string value) {
         var result = Fraction.FromString(value, NumberStyles.Any, CultureInfo.InvariantCulture, false);
         result.IsPositiveInfinity.Should().BeTrue(); // this is still considered "a positive infinity"
-        result.Should().NotBe(Fraction.PositiveInfinity); // however it isn't strictly equal to the PositiveInfinity
-        result.Should().Be(new Fraction(10, 0, false)); // rather it's a non-normalized version
-        result.Equals(Fraction.PositiveInfinity).Should().BeTrue(); // which can be reduced to PositiveInfinity
+        ((object)result).Should().NotBe(Fraction.PositiveInfinity, StrictTestComparer.Instance); // however it isn't strictly equal to the PositiveInfinity
+        ((object)result).Should().Be(new Fraction(10, 0, false), StrictTestComparer.Instance); // rather it's a non-normalized version
+        result.Equals(Fraction.PositiveInfinity).Should().BeTrue(); // should be equal to PositiveInfinity
     }
 }
 
@@ -1382,8 +1382,8 @@ public class When_creating_a_fraction_from_the_string_minus_10_over_0_without_no
         string value) {
         var result = Fraction.FromString(value, NumberStyles.Any, CultureInfo.InvariantCulture, false);
         result.IsNegativeInfinity.Should().BeTrue(); // this is still considered "a negative infinity"
-        result.Should().NotBe(Fraction.NegativeInfinity); // however it isn't strictly equal to the NegativeInfinity
-        result.Should().Be(new Fraction(-10, 0, false)); // rather it's a non-normalized version
+        ((object)result).Should().NotBe(Fraction.NegativeInfinity, StrictTestComparer.Instance); // however it isn't strictly equal to the NegativeInfinity
+        ((object)result).Should().Be(new Fraction(-10, 0, false), StrictTestComparer.Instance); // rather it's a non-normalized version
         result.Equals(Fraction.NegativeInfinity).Should().BeTrue(); // which can be reduced to NegativeInfinity
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromString/Method_FromString.cs
@@ -1262,7 +1262,7 @@ public class When_creating_a_fraction_from_the_string_0_over_0 : Spec {
     public void The_result_should_be_NaN(
         [Values("0/0", "-0/0", " -0/0", "-0/ 0", "0 /-0", "0 / -0")]
         string value) {
-        Fraction.FromString(value).Should().Be(Fraction.NaN);
+        Fraction.FromString(value).IsNaN.Should().BeTrue();
     }
 }
 
@@ -1298,7 +1298,7 @@ public class When_creating_a_fraction_from_the_string_0_over_10_without_normaliz
         result.IsZero.Should().BeTrue(); // this is still considered "a zero"
         result.Should().NotBe(Fraction.Zero); // however it isn't strictly equal to the Zero
         result.Should().Be(new Fraction(0, 10, false)); // rather it's a non-normalized version
-        result.IsEquivalentTo(Fraction.Zero).Should().BeTrue(); // which can be reduced to Zero
+        result.Equals(Fraction.Zero).Should().BeTrue(); // which can be reduced to Zero
     }
 }
 
@@ -1320,7 +1320,7 @@ public class When_creating_a_fraction_from_the_string_0_over_minus_10_without_no
         result.IsZero.Should().BeTrue(); // this is still considered "a zero"
         result.Should().NotBe(Fraction.Zero); // however it isn't strictly equal to the Zero
         result.Should().Be(new Fraction(0, -10, false)); // rather it's a non-normalized version
-        result.IsEquivalentTo(Fraction.Zero).Should().BeTrue(); // which can be reduced to Zero
+        result.Equals(Fraction.Zero).Should().BeTrue(); // which can be reduced to Zero
     }
 }
 
@@ -1351,7 +1351,7 @@ public class When_creating_a_fraction_from_the_string_10_over_0_without_normaliz
         result.IsPositiveInfinity.Should().BeTrue(); // this is still considered "a positive infinity"
         result.Should().NotBe(Fraction.PositiveInfinity); // however it isn't strictly equal to the PositiveInfinity
         result.Should().Be(new Fraction(10, 0, false)); // rather it's a non-normalized version
-        result.IsEquivalentTo(Fraction.PositiveInfinity).Should().BeTrue(); // which can be reduced to PositiveInfinity
+        result.Equals(Fraction.PositiveInfinity).Should().BeTrue(); // which can be reduced to PositiveInfinity
     }
 }
 
@@ -1384,6 +1384,6 @@ public class When_creating_a_fraction_from_the_string_minus_10_over_0_without_no
         result.IsNegativeInfinity.Should().BeTrue(); // this is still considered "a negative infinity"
         result.Should().NotBe(Fraction.NegativeInfinity); // however it isn't strictly equal to the NegativeInfinity
         result.Should().Be(new Fraction(-10, 0, false)); // rather it's a non-normalized version
-        result.IsEquivalentTo(Fraction.NegativeInfinity).Should().BeTrue(); // which can be reduced to NegativeInfinity
+        result.Equals(Fraction.NegativeInfinity).Should().BeTrue(); // which can be reduced to NegativeInfinity
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Multiply/Method_Multiply.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Multiply/Method_Multiply.cs
@@ -208,36 +208,37 @@ public class When_multiplying_with_NaN {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // NaN with NaN
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN, Fraction.NaN);
             // NaN with any number
-            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(5, 4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, -5, false)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.One).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(4, 5)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, 4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-4, 5)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(5, -5, false)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(5, 4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, -5, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.One, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(4, 5), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, 4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-4, 5), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(5, -5, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity, Fraction.NaN);
             // Any number with NaN
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.One, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.One, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_is_always_NaN(Fraction a, Fraction b) {
-        return a.Multiply(b);
+    public void The_result_is_always_NaN(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Multiply(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 
@@ -246,62 +247,43 @@ public class When_multiplying_with_infinity {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // positive infinity with positive infinity
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false), Fraction.PositiveInfinity);
 
             // positive infinity with any other number
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 4))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4, 5))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 4))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4, 5))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 4), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4, 5), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 4), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4, 5), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false), Fraction.NegativeInfinity);
 
             // negative infinity with negative infinity
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false), Fraction.PositiveInfinity);
 
             // negative infinity with any other number
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 4))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4, 5))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 4))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4, 5))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 4), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4, 5), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 4), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4, 5), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 0, false), Fraction.NegativeInfinity);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_is_always_NaN_or_Infinity(Fraction a, Fraction b) => a.Multiply(b);
+    public void The_result_is_always_NaN_or_Infinity(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Multiply(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
+    }
 }
 
 [TestFixture]

--- a/tests/Fractions.Tests/FractionSpecs/Negate/Method_Negate.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Negate/Method_Negate.cs
@@ -91,7 +91,7 @@ public class When_negating_a_fraction_with_0_as_numerator_and_minus_1_as_denomin
         _result.IsZero.Should().BeTrue();
         _result.Should().NotBe(Fraction.Zero);
         _result.State.Should().Be(FractionState.Unknown);
-        _result.IsEquivalentTo(Fraction.Zero).Should().BeTrue();
+        _result.Equals(Fraction.Zero).Should().BeTrue();
     }
 }
 
@@ -123,7 +123,7 @@ public class When_negating_a_fraction_with_0_as_numerator_and_4_as_denominator :
         _result.IsZero.Should().BeTrue();
         _result.Should().NotBe(Fraction.Zero);
         _result.State.Should().Be(FractionState.Unknown);
-        _result.IsEquivalentTo(Fraction.Zero).Should().BeTrue();
+        _result.Equals(Fraction.Zero).Should().BeTrue();
     }
 }
 
@@ -155,7 +155,7 @@ public class When_negating_a_fraction_with_0_as_numerator_and_minus_4_as_denomin
         _result.IsZero.Should().BeTrue();
         _result.Should().NotBe(Fraction.Zero);
         _result.State.Should().Be(FractionState.Unknown);
-        _result.IsEquivalentTo(Fraction.Zero).Should().BeTrue();
+        _result.Equals(Fraction.Zero).Should().BeTrue();
     }
 }
 
@@ -240,7 +240,7 @@ public class When_negating_a_fraction_with_4_as_numerator_and_0_as_denominator :
         _result.IsNegativeInfinity.Should().BeTrue();
         _result.Should().NotBe(Fraction.NegativeInfinity);
         _result.State.Should().Be(FractionState.Unknown);
-        _result.IsEquivalentTo(Fraction.NegativeInfinity).Should().BeTrue();
+        _result.Equals(Fraction.NegativeInfinity).Should().BeTrue();
     }
 }
 
@@ -270,7 +270,7 @@ public class When_negating_a_fraction_with_minus_4_as_numerator_and_0_as_denomin
         _result.IsPositiveInfinity.Should().BeTrue();
         _result.Should().NotBe(Fraction.PositiveInfinity);
         _result.State.Should().Be(FractionState.Unknown);
-        _result.IsEquivalentTo(Fraction.PositiveInfinity).Should().BeTrue();
+        _result.Equals(Fraction.PositiveInfinity).Should().BeTrue();
     }
 }
 

--- a/tests/Fractions.Tests/FractionSpecs/Negate/Method_Negate.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Negate/Method_Negate.cs
@@ -65,7 +65,6 @@ public class When_negating_a_fraction_with_0_as_numerator_and_1_as_denominator :
 }
 
 [TestFixture]
-// German: Wenn ein Bruch mit 0 als Zähler und -1 als Nenner negiert wird
 public class When_negating_a_fraction_with_0_as_numerator_and_minus_1_as_denominator : Spec {
     private Fraction _result;
 
@@ -74,29 +73,25 @@ public class When_negating_a_fraction_with_0_as_numerator_and_minus_1_as_denomin
     }
 
     [Test]
-    // German: Der resultierende Bruch sollte 0 als Zähler haben
     public void The_resulting_fraction_should_have_0_as_numerator() {
         _result.Numerator.Should().Be(0);
     }
 
     [Test]
-    // German: Der resultierende Bruch sollte 1 als Nenner haben
     public void The_resulting_fraction_should_have_minus_1_as_denominator() {
         _result.Denominator.Should().Be(-1);
     }
 
     [Test]
-    // German: Der Bruch sollte 0 sein
     public void The_fraction_should_be_equivalent_to_zero() {
         _result.IsZero.Should().BeTrue();
-        _result.Should().NotBe(Fraction.Zero);
+        ((object)_result).Should().NotBe(Fraction.Zero, StrictTestComparer.Instance);
         _result.State.Should().Be(FractionState.Unknown);
         _result.Equals(Fraction.Zero).Should().BeTrue();
     }
 }
 
 [TestFixture]
-// German: Wenn ein Bruch mit 0 als Zähler und 4 als Nenner negiert wird
 public class When_negating_a_fraction_with_0_as_numerator_and_4_as_denominator : Spec {
     private Fraction _result;
 
@@ -105,30 +100,26 @@ public class When_negating_a_fraction_with_0_as_numerator_and_4_as_denominator :
     }
 
     [Test]
-    // German: Der resultierende Bruch sollte 0 als Zähler haben
     public void The_resulting_fraction_should_have_0_as_numerator() {
         _result.Numerator.Should().Be(0);
     }
 
     [Test]
-    // German: Der resultierende Bruch sollte 4 als Nenner haben
     public void The_resulting_fraction_should_have_4_as_denominator() {
         _result.Denominator
             .Should().Be(4);
     }
 
     [Test]
-    // German: Der Bruch sollte 0 sein
     public void The_fraction_should_be_equivalent_to_zero() {
         _result.IsZero.Should().BeTrue();
-        _result.Should().NotBe(Fraction.Zero);
+        ((object)_result).Should().NotBe(Fraction.Zero, StrictTestComparer.Instance);
         _result.State.Should().Be(FractionState.Unknown);
         _result.Equals(Fraction.Zero).Should().BeTrue();
     }
 }
 
 [TestFixture]
-// German: Wenn ein Bruch mit 0 als Zähler und -4 als Nenner negiert wird
 public class When_negating_a_fraction_with_0_as_numerator_and_minus_4_as_denominator : Spec {
     private Fraction _result;
 
@@ -137,23 +128,20 @@ public class When_negating_a_fraction_with_0_as_numerator_and_minus_4_as_denomin
     }
 
     [Test]
-    // German: Der resultierende Bruch sollte 0 als Zähler haben
     public void The_resulting_fraction_should_have_0_as_numerator() {
         _result.Numerator
             .Should().Be(0);
     }
 
     [Test]
-    // German: Der resultierende Bruch sollte 4 als Nenner haben
     public void The_resulting_fraction_should_have_minus_4_as_denominator() {
         _result.Denominator.Should().Be(-4);
     }
 
     [Test]
-    // German: Der Bruch sollte 0 sein
     public void The_fraction_should_be_0() {
         _result.IsZero.Should().BeTrue();
-        _result.Should().NotBe(Fraction.Zero);
+        ((object)_result).Should().NotBe(Fraction.Zero, StrictTestComparer.Instance);
         _result.State.Should().Be(FractionState.Unknown);
         _result.Equals(Fraction.Zero).Should().BeTrue();
     }
@@ -238,7 +226,7 @@ public class When_negating_a_fraction_with_4_as_numerator_and_0_as_denominator :
     [Test]
     public void The_fraction_should_be_0() {
         _result.IsNegativeInfinity.Should().BeTrue();
-        _result.Should().NotBe(Fraction.NegativeInfinity);
+        ((object)_result).Should().NotBe(Fraction.NegativeInfinity, StrictTestComparer.Instance);
         _result.State.Should().Be(FractionState.Unknown);
         _result.Equals(Fraction.NegativeInfinity).Should().BeTrue();
     }
@@ -268,7 +256,7 @@ public class When_negating_a_fraction_with_minus_4_as_numerator_and_0_as_denomin
     [Test]
     public void The_fraction_should_be_0() {
         _result.IsPositiveInfinity.Should().BeTrue();
-        _result.Should().NotBe(Fraction.PositiveInfinity);
+        ((object)_result).Should().NotBe(Fraction.PositiveInfinity, StrictTestComparer.Instance);
         _result.State.Should().Be(FractionState.Unknown);
         _result.Equals(Fraction.PositiveInfinity).Should().BeTrue();
     }
@@ -332,9 +320,12 @@ public class Negating_a_fraction_using_the_minus_operator : Spec {
     ];
 
     public static IEnumerable<TestCaseData> TestCases =>
-        FractionsToTest.Select(x => new TestCaseData(x).Returns(x.Negate()));
+        FractionsToTest.Select(x => new TestCaseData(x, x.Negate()));
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction Is_the_same_as_calling_the_negate_method(Fraction fraction) => -fraction;
+    public void Is_the_same_as_calling_the_negate_method(Fraction fraction, Fraction expected) {
+        var result = -fraction;
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
+    }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Pow/Method_Pow.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Pow/Method_Pow.cs
@@ -5,108 +5,77 @@ using Tests.Fractions;
 namespace Fractions.Tests.FractionSpecs.Pow;
 
 [TestFixture]
-// German: Wenn an einem Bruch die Potenz angewendet wird
 public class When_exponentiation_is_applied_to_a_fraction : Spec {
     private static IEnumerable TestCases {
         get {
             // positive infinity
-            yield return new TestCaseData(Fraction.PositiveInfinity, 0).Returns(Fraction.One);
-            yield return new TestCaseData(Fraction.PositiveInfinity, 1).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, -1).Returns(Fraction.Zero);
-            yield return new TestCaseData(Fraction.PositiveInfinity, 2).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, -2).Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(10, 0, false), 0).Returns(Fraction.One);
-            yield return new TestCaseData(new Fraction(10, 0, false), 1).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(new Fraction(10, 0, false), -1).Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(10, 0, false), 2).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(new Fraction(10, 0, false), -2).Returns(Fraction.Zero);
+            yield return new TestCaseData(Fraction.PositiveInfinity, 0, Fraction.One);
+            yield return new TestCaseData(Fraction.PositiveInfinity, 1, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, -1, Fraction.Zero);
+            yield return new TestCaseData(Fraction.PositiveInfinity, 2, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, -2, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(10, 0, false), 0, Fraction.One);
+            yield return new TestCaseData(new Fraction(10, 0, false), 1, Fraction.PositiveInfinity);
+            yield return new TestCaseData(new Fraction(10, 0, false), -1, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(10, 0, false), 2, Fraction.PositiveInfinity);
+            yield return new TestCaseData(new Fraction(10, 0, false), -2, Fraction.Zero);
             // positive numbers
-            yield return new TestCaseData(new Fraction(1, 3), 2)
-                .Returns(new Fraction(1, 9));
-            yield return new TestCaseData(new Fraction(3), -1)
-                .Returns(new Fraction(1, 3));
-            yield return new TestCaseData(new Fraction(3), 0)
-                .Returns(new Fraction(1));
-            yield return new TestCaseData(new Fraction(3), 2)
-                .Returns(new Fraction(9));
-            yield return new TestCaseData(new Fraction(3), 3)
-                .Returns(new Fraction(27));
-            yield return new TestCaseData(new Fraction(3), -2)
-                .Returns(new Fraction(1, 9));
-            yield return new TestCaseData(new Fraction(3, 3, false), 2)
-                .Returns(new Fraction(9, 9, true));
-            yield return new TestCaseData(new Fraction(3, 3, false), -2)
-                .Returns(new Fraction(9, 9, true));
-            yield return new TestCaseData(Fraction.FromDecimal(1.0000m, false), 2)
-                .Returns(Fraction.FromDecimal(1m));
-            yield return new TestCaseData(Fraction.FromDecimal(0.1000m, false), 2)
-                .Returns(Fraction.FromDecimal(0.01m));
-            yield return new TestCaseData(Fraction.FromDecimal(1.0000m, false), -2)
-                .Returns(Fraction.FromDecimal(1m));
-            yield return new TestCaseData(Fraction.FromDecimal(0.1000m, false), -2)
-                .Returns(Fraction.FromDecimal(100m));
+            yield return new TestCaseData(new Fraction(1, 3), 2, new Fraction(1, 9));
+            yield return new TestCaseData(new Fraction(3), -1, new Fraction(1, 3));
+            yield return new TestCaseData(new Fraction(3), 0, new Fraction(1));
+            yield return new TestCaseData(new Fraction(3), 2, new Fraction(9));
+            yield return new TestCaseData(new Fraction(3), 3, new Fraction(27));
+            yield return new TestCaseData(new Fraction(3), -2, new Fraction(1, 9));
+            yield return new TestCaseData(new Fraction(3, 3, false), 2, new Fraction(9, 9, true));
+            yield return new TestCaseData(new Fraction(3, 3, false), -2, new Fraction(9, 9, true));
+            yield return new TestCaseData(Fraction.FromDecimal(1.0000m, false), 2, Fraction.FromDecimal(1m));
+            yield return new TestCaseData(Fraction.FromDecimal(0.1000m, false), 2, Fraction.FromDecimal(0.01m));
+            yield return new TestCaseData(Fraction.FromDecimal(1.0000m, false), -2, Fraction.FromDecimal(1m));
+            yield return new TestCaseData(Fraction.FromDecimal(0.1000m, false), -2, Fraction.FromDecimal(100m));
             // zero
-            yield return new TestCaseData(Fraction.Zero, 0)
-                .Returns(Fraction.One);
-            yield return new TestCaseData(Fraction.Zero, 1)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(Fraction.Zero, -1)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.Zero, 2)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(0, 10, false), 0)
-                .Returns(Fraction.One);
-            yield return new TestCaseData(new Fraction(0, -10, false), 0)
-                .Returns(Fraction.One);
-            yield return new TestCaseData(new Fraction(0, 10, false), 1)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(0, -10, false), -1)
-                .Returns(Fraction.PositiveInfinity); // TODO?
-            yield return new TestCaseData(new Fraction(0, 10, false), 2)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(0, -10, false), -2)
-                .Returns(Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.Zero, 0, Fraction.One);
+            yield return new TestCaseData(Fraction.Zero, 1, Fraction.Zero);
+            yield return new TestCaseData(Fraction.Zero, -1, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.Zero, 2, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(0, 10, false), 0, Fraction.One);
+            yield return new TestCaseData(new Fraction(0, -10, false), 0, Fraction.One);
+            yield return new TestCaseData(new Fraction(0, 10, false), 1, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(0, -10, false), -1, Fraction.PositiveInfinity); // TODO?
+            yield return new TestCaseData(new Fraction(0, 10, false), 2, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(0, -10, false), -2, Fraction.PositiveInfinity);
             // negative numbers
-            yield return new TestCaseData(new Fraction(-1, 3), 2)
-                .Returns(new Fraction(1, 9));
-            yield return new TestCaseData(new Fraction(-3), -1)
-                .Returns(new Fraction(-1, 3));
-            yield return new TestCaseData(new Fraction(-3), 0)
-                .Returns(new Fraction(1));
-            yield return new TestCaseData(new Fraction(-3), 2)
-                .Returns(new Fraction(9));
-            yield return new TestCaseData(new Fraction(-3), 3)
-                .Returns(new Fraction(-27));
-            yield return new TestCaseData(new Fraction(-3), -2)
-                .Returns(new Fraction(1, 9));
-            yield return new TestCaseData(new Fraction(3, -3, false), 2)
-                .Returns(new Fraction(9, 9, true));
-            yield return new TestCaseData(new Fraction(3, -3, false), -2)
-                .Returns(new Fraction(9, 9, true));
+            yield return new TestCaseData(new Fraction(-1, 3), 2, new Fraction(1, 9));
+            yield return new TestCaseData(new Fraction(-3), -1, new Fraction(-1, 3));
+            yield return new TestCaseData(new Fraction(-3), 0, new Fraction(1));
+            yield return new TestCaseData(new Fraction(-3), 2, new Fraction(9));
+            yield return new TestCaseData(new Fraction(-3), 3, new Fraction(-27));
+            yield return new TestCaseData(new Fraction(-3), -2, new Fraction(1, 9));
+            yield return new TestCaseData(new Fraction(3, -3, false), 2, new Fraction(9, 9, true));
+            yield return new TestCaseData(new Fraction(3, -3, false), -2, new Fraction(9, 9, true));
             // negative infinity
-            yield return new TestCaseData(Fraction.NegativeInfinity, 0).Returns(Fraction.One);
-            yield return new TestCaseData(Fraction.NegativeInfinity, 1).Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, -1).Returns(Fraction.Zero);
-            yield return new TestCaseData(Fraction.NegativeInfinity, 2).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, -2).Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(-10, 0, false), 0).Returns(Fraction.One);
-            yield return new TestCaseData(new Fraction(-10, 0, false), 1).Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(new Fraction(-10, 0, false), -1).Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(-10, 0, false), 2).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(new Fraction(-10, 0, false), -2).Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(-10, 0, false), 3).Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(new Fraction(-10, 0, false), -3).Returns(Fraction.Zero);
+            yield return new TestCaseData(Fraction.NegativeInfinity, 0, Fraction.One);
+            yield return new TestCaseData(Fraction.NegativeInfinity, 1, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, -1, Fraction.Zero);
+            yield return new TestCaseData(Fraction.NegativeInfinity, 2, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, -2, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(-10, 0, false), 0, Fraction.One);
+            yield return new TestCaseData(new Fraction(-10, 0, false), 1, Fraction.NegativeInfinity);
+            yield return new TestCaseData(new Fraction(-10, 0, false), -1, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(-10, 0, false), 2, Fraction.PositiveInfinity);
+            yield return new TestCaseData(new Fraction(-10, 0, false), -2, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(-10, 0, false), 3, Fraction.NegativeInfinity);
+            yield return new TestCaseData(new Fraction(-10, 0, false), -3, Fraction.Zero);
             // NaN
-            yield return new TestCaseData(Fraction.NaN, 0).Returns(Fraction.One);
-            yield return new TestCaseData(Fraction.NaN, 1).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, -1).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, 0, Fraction.One);
+            yield return new TestCaseData(Fraction.NaN, 1, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, -1, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    // German: Das Ergebnis sollte korrekt sein
-    public Fraction The_result_should_be_correct(Fraction fraction, int power) {
-        return Fraction.Pow(fraction, power);
+    public void The_result_should_be_correct(Fraction fraction, int power, Fraction expected) {
+        var result = Fraction.Pow(fraction, power);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Remainder/Method_Remainder.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Remainder/Method_Remainder.cs
@@ -208,7 +208,7 @@ public class When_calculating_6_mod_0 : Spec {
 
     [Test]
     public void Should_return_NaN_as_the_result() {
-        _result.Should().Be(Fraction.NaN);
+        _result.IsNaN.Should().BeTrue();
     }
 }
 

--- a/tests/Fractions.Tests/FractionSpecs/Remainder/Method_Remainder.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Remainder/Method_Remainder.cs
@@ -308,29 +308,22 @@ public class When_calculating_60_mod_100 : Spec {
 public class When_calculating_the_remainder_of_Zero : Spec {
     public static IEnumerable<TestCaseData> TestCases {
         get {
-            yield return new TestCaseData(Fraction.Zero, Fraction.Zero)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(default(Fraction), Fraction.One)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(Fraction.Zero, new Fraction(4))
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(BigInteger.Zero, 10, false), Fraction.One)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(BigInteger.Zero, -10, false), Fraction.Two)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(Fraction.Zero, Fraction.NaN)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.Zero, Fraction.PositiveInfinity)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(Fraction.Zero, Fraction.NegativeInfinity)
-                .Returns(Fraction.Zero);
+            yield return new TestCaseData(Fraction.Zero, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(default(Fraction), Fraction.One, Fraction.Zero);
+            yield return new TestCaseData(Fraction.Zero, new Fraction(4), Fraction.Zero);
+            yield return new TestCaseData(new Fraction(BigInteger.Zero, 10, false), Fraction.One, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(BigInteger.Zero, -10, false), Fraction.Two, Fraction.Zero);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.Zero, Fraction.PositiveInfinity, Fraction.Zero);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NegativeInfinity, Fraction.Zero);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_should_be_Zero_or_NaN(Fraction fraction, Fraction divisor) {
-        return fraction.Remainder(divisor);
+    public void The_result_should_be_Zero_or_NaN(Fraction fraction, Fraction divisor, Fraction expected) {
+        var result = fraction.Remainder(divisor);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 
@@ -338,20 +331,21 @@ public class When_calculating_the_remainder_of_Zero : Spec {
 public class When_calculating_the_remainder_of_NaN : Spec {
     public static IEnumerable<TestCaseData> TestCases {
         get {
-            yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(10, BigInteger.Zero, false), Fraction.One).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-4), Fraction.NaN);
+            yield return new TestCaseData(new Fraction(10, BigInteger.Zero, false), Fraction.One, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_should_be_NaN(Fraction fraction, Fraction divisor) {
-        return fraction.Remainder(divisor);
+    public void The_result_should_be_NaN(Fraction fraction, Fraction divisor, Fraction expected) {
+        var result = fraction.Remainder(divisor);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 
@@ -360,43 +354,30 @@ public class When_calculating_the_remainder_of_Infinity : Spec {
     public static IEnumerable<TestCaseData> TestCases {
         get {
             // positive infinity
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4))
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4))
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(10, BigInteger.Zero, false), Fraction.One)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4), Fraction.NaN);
+            yield return new TestCaseData(new Fraction(10, BigInteger.Zero, false), Fraction.One, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity, Fraction.NaN);
 
             // negative infinity
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4))
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4))
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-10, BigInteger.Zero, false), Fraction.Two)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4), Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-10, BigInteger.Zero, false), Fraction.Two, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_should_be_NaN(Fraction fraction, Fraction divisor) {
-        return fraction.Remainder(divisor);
+    public void The_result_should_be_NaN(Fraction fraction, Fraction divisor, Fraction expected) {
+        var result = fraction.Remainder(divisor);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 
@@ -405,30 +386,23 @@ public class When_calculating_the_remainder_of_a_finite_number_with_Infinity : S
     public static IEnumerable<TestCaseData> TestCases {
         get {
             // positive infinity
-            yield return new TestCaseData(Fraction.Zero, Fraction.PositiveInfinity)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(4), Fraction.PositiveInfinity)
-                .Returns(new Fraction(4));
-            yield return new TestCaseData(new Fraction(-4), Fraction.PositiveInfinity)
-                .Returns(new Fraction(-4));
-            yield return new TestCaseData(Fraction.Two, new Fraction(10, BigInteger.Zero, false))
-                .Returns(Fraction.Two);
+            yield return new TestCaseData(Fraction.Zero, Fraction.PositiveInfinity, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(4), Fraction.PositiveInfinity, new Fraction(4));
+            yield return new TestCaseData(new Fraction(-4), Fraction.PositiveInfinity, new Fraction(-4));
+            yield return new TestCaseData(Fraction.Two, new Fraction(10, BigInteger.Zero, false), Fraction.Two);
 
             // negative infinity
-            yield return new TestCaseData(Fraction.Zero, Fraction.NegativeInfinity)
-                .Returns(Fraction.Zero);
-            yield return new TestCaseData(new Fraction(4), Fraction.NegativeInfinity)
-                .Returns(new Fraction(4));
-            yield return new TestCaseData(new Fraction(-4), Fraction.NegativeInfinity)
-                .Returns(new Fraction(-4));
-            yield return new TestCaseData(Fraction.Two, new Fraction(-10, BigInteger.Zero, false))
-                .Returns(Fraction.Two);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NegativeInfinity, Fraction.Zero);
+            yield return new TestCaseData(new Fraction(4), Fraction.NegativeInfinity, new Fraction(4));
+            yield return new TestCaseData(new Fraction(-4), Fraction.NegativeInfinity, new Fraction(-4));
+            yield return new TestCaseData(Fraction.Two, new Fraction(-10, BigInteger.Zero, false), Fraction.Two);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_should_be_the_same_number(Fraction fraction, Fraction divisor) {
-        return fraction.Remainder(divisor);
+    public void The_result_should_be_the_same_number(Fraction fraction, Fraction divisor, Fraction expected) {
+        var result = fraction.Remainder(divisor);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Round/Method_Round.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Round/Method_Round.cs
@@ -56,107 +56,90 @@ public class When_rounding_a_decimal_fraction : Spec {
         from decimalFraction in DecimalFractions
         from decimalPlaces in DecimalPlaces
         from midpointRounding in RoundingModes
-        select new TestCaseData(decimalFraction, decimalPlaces, midpointRounding)
-            .Returns(new Fraction(decimal.Round((decimal)decimalFraction, decimalPlaces, midpointRounding)));
+        select new TestCaseData(decimalFraction, decimalPlaces, midpointRounding,
+            new Fraction(decimal.Round((decimal)decimalFraction, decimalPlaces, midpointRounding)));
 
     [Test]
     [TestCaseSource(nameof(RoundToFractionTestCases))]
-    public Fraction The_fractional_result_should_be_correct_for_all_decimal_values(Fraction fraction, int decimalPlaces,
-        MidpointRounding roundingMode) {
-        return Fraction.Round(fraction, decimalPlaces, roundingMode);
+    public void The_fractional_result_should_be_correct_for_all_decimal_values(Fraction fraction, int decimalPlaces,
+        MidpointRounding roundingMode, Fraction expected) {
+        var result = Fraction.Round(fraction, decimalPlaces, roundingMode);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 
     private static IEnumerable RoundRepeatingFractionTestCases {
         get {
             foreach (var roundingMode in new[] { MidpointRounding.ToEven, MidpointRounding.AwayFromZero }) {
                 // one third: (1/3) rounded to 2 decimals should always be 0.33 (33/100)
-                yield return new TestCaseData(new Fraction(1, 3), 2, roundingMode)
-                    .Returns(new Fraction(33, 100)); // 0.33
+                yield return new TestCaseData(new Fraction(1, 3), 2, roundingMode, new Fraction(33, 100)); // 0.33
                 // minus one third: (-1/3) rounded to 2 decimals should always be -0.33 (-33/100)
-                yield return new TestCaseData(new Fraction(-1, 3), 2, roundingMode)
-                    .Returns(new Fraction(-33, 100)); // -0.33
+                yield return new TestCaseData(new Fraction(-1, 3), 2, roundingMode, new Fraction(-33, 100)); // -0.33
             }
 
 #if NET
             foreach (var roundingMode in new[] { MidpointRounding.ToNegativeInfinity, MidpointRounding.ToZero }) {
                 // one third: (1/3) rounded to 2 decimals should always be 0.33 (33/100)
-                yield return new TestCaseData(new Fraction(1, 3), 2, roundingMode)
-                    .Returns(new Fraction(33, 100)); // 0.33
+                yield return new TestCaseData(new Fraction(1, 3), 2, roundingMode, new Fraction(33, 100)); // 0.33
             }
 
             // one third: (1/3) rounded to 2 decimals should always be 0.34 (34/100) when rounding up
-            yield return new TestCaseData(new Fraction(1, 3), 2, MidpointRounding.ToPositiveInfinity)
-                .Returns(new Fraction(34, 100)); // 0.34
+            yield return new TestCaseData(new Fraction(1, 3), 2, MidpointRounding.ToPositiveInfinity, new Fraction(34, 100)); // 0.34
 
             foreach (var roundingMode in new[] { MidpointRounding.ToZero, MidpointRounding.ToPositiveInfinity }) {
                 // minus one third: (-1/3) rounded to 2 decimals should always be -0.33 (-33/100)
-                yield return new TestCaseData(new Fraction(-1, 3), 2, roundingMode)
-                    .Returns(new Fraction(-33, 100)); // -0.33
+                yield return new TestCaseData(new Fraction(-1, 3), 2, roundingMode, new Fraction(-33, 100)); // -0.33
             }
 
             // minus one third: (-1/3) rounded to 2 decimals should always be -0.34 (-34/100) when rounding down
-            yield return new TestCaseData(new Fraction(-1, 3), 2, MidpointRounding.ToNegativeInfinity)
-                .Returns(new Fraction(-34, 100)); // -0.34
+            yield return new TestCaseData(new Fraction(-1, 3), 2, MidpointRounding.ToNegativeInfinity, new Fraction(-34, 100)); // -0.34
 #endif
             foreach (var roundingMode in new[] { MidpointRounding.ToEven, MidpointRounding.AwayFromZero }) {
                 // two thirds: (2/3) rounded to 2 decimals should always be 0.67 (67/100)
-                yield return new TestCaseData(new Fraction(2, 3), 2, roundingMode)
-                    .Returns(new Fraction(67, 100)); // 0.67
+                yield return new TestCaseData(new Fraction(2, 3), 2, roundingMode, new Fraction(67, 100)); // 0.67
                 // minus one third: (-2/3) rounded to 2 decimals should always be -0.67 (-67/100)
-                yield return new TestCaseData(new Fraction(-2, 3), 2, roundingMode)
-                    .Returns(new Fraction(-67, 100)); // -0.67
+                yield return new TestCaseData(new Fraction(-2, 3), 2, roundingMode, new Fraction(-67, 100)); // -0.67
             }
 #if NET
             // two thirds: (2/3) rounded to 2 decimals should always be 0.67 (67/100)
-            yield return new TestCaseData(new Fraction(2, 3), 2, MidpointRounding.ToPositiveInfinity)
-                .Returns(new Fraction(67, 100)); // 0.67
+            yield return new TestCaseData(new Fraction(2, 3), 2, MidpointRounding.ToPositiveInfinity, new Fraction(67, 100)); // 0.67
 
             foreach (var roundingMode in new[] { MidpointRounding.ToZero, MidpointRounding.ToNegativeInfinity }) {
                 // two thirds: (2/3) rounded to 2 decimals should always be 0.66 (66/100) when rounded down
-                yield return new TestCaseData(new Fraction(2, 3), 2, roundingMode)
-                    .Returns(new Fraction(66, 100)); // 0.66
+                yield return new TestCaseData(new Fraction(2, 3), 2, roundingMode, new Fraction(66, 100)); // 0.66
             }
 
             foreach (var roundingMode in new[] { MidpointRounding.ToZero, MidpointRounding.ToPositiveInfinity }) {
                 // minus two thirds: (-2/3) rounded to 2 decimals should always be -0.66 (-66/100)
-                yield return new TestCaseData(new Fraction(-2, 3), 2, roundingMode)
-                    .Returns(new Fraction(-66, 100)); // 0.66
+                yield return new TestCaseData(new Fraction(-2, 3), 2, roundingMode, new Fraction(-66, 100)); // 0.66
             }
 
             // minus two thirds: (-2/3) rounded to 2 decimals should always be -0.67 (-67/100) when rounded down
-            yield return new TestCaseData(new Fraction(-2, 3), 2, MidpointRounding.ToNegativeInfinity)
-                .Returns(new Fraction(-67, 100)); // 0.67
+            yield return new TestCaseData(new Fraction(-2, 3), 2, MidpointRounding.ToNegativeInfinity, new Fraction(-67, 100)); // 0.67
 #endif
 
             foreach (var roundingMode in new[] { MidpointRounding.ToEven, MidpointRounding.AwayFromZero }) {
                 // four thirds: (4/3) rounded to 2 decimals should always be 1.33 (133/100)
-                yield return new TestCaseData(new Fraction(4, 3), 2, roundingMode)
-                    .Returns(new Fraction(133, 100)); // 1.33
+                yield return new TestCaseData(new Fraction(4, 3), 2, roundingMode, new Fraction(133, 100)); // 1.33
                 // minus four thirds (-4/3) rounded to 2 decimals should always be -1.33 (-133/100)
-                yield return new TestCaseData(new Fraction(-4, 3), 2, roundingMode)
-                    .Returns(new Fraction(-133, 100)); // -1.33
+                yield return new TestCaseData(new Fraction(-4, 3), 2, roundingMode, new Fraction(-133, 100)); // -1.33
             }
 
 #if NET
             foreach (var roundingMode in new[] { MidpointRounding.ToNegativeInfinity, MidpointRounding.ToZero }) {
                 // four thirds: (4/3) rounded to 2 decimals should always be 1.33 (133/100)
-                yield return new TestCaseData(new Fraction(4, 3), 2, roundingMode)
-                    .Returns(new Fraction(133, 100)); // 1.33
+                yield return new TestCaseData(new Fraction(4, 3), 2, roundingMode, new Fraction(133, 100)); // 1.33
             }
 
             // four thirds: (4/3) rounded to 2 decimals should always be 1.34 (134/100) when rounding up
-            yield return new TestCaseData(new Fraction(4, 3), 2, MidpointRounding.ToPositiveInfinity)
-                .Returns(new Fraction(134, 100)); // 1.34
+            yield return new TestCaseData(new Fraction(4, 3), 2, MidpointRounding.ToPositiveInfinity, new Fraction(134, 100)); // 1.34
 
             foreach (var roundingMode in new[] { MidpointRounding.ToZero, MidpointRounding.ToPositiveInfinity }) {
                 // minus four thirds: (-4/3) rounded to 2 decimals should always be -1.33 (-133/100)
-                yield return new TestCaseData(new Fraction(-4, 3), 2, roundingMode)
-                    .Returns(new Fraction(-133, 100)); // -1.33
+                yield return new TestCaseData(new Fraction(-4, 3), 2, roundingMode, new Fraction(-133, 100)); // -1.33
             }
 
             // minus four thirds: (-4/3) rounded to 2 decimals should always be -1.34 (-134/100) when rounding down
-            yield return new TestCaseData(new Fraction(-4, 3), 2, MidpointRounding.ToNegativeInfinity)
-                .Returns(new Fraction(-134, 100)); // -1.34
+            yield return new TestCaseData(new Fraction(-4, 3), 2, MidpointRounding.ToNegativeInfinity, new Fraction(-134, 100)); // -1.34
 #endif
         }
     }
@@ -164,9 +147,10 @@ public class When_rounding_a_decimal_fraction : Spec {
 
     [Test]
     [TestCaseSource(nameof(RoundRepeatingFractionTestCases))]
-    public Fraction The_fractional_result_should_be_correct_for_all_repeating_fractions(Fraction fraction,
-        int decimalPlaces, MidpointRounding roundingMode) {
-        return Fraction.Round(fraction, decimalPlaces, roundingMode);
+    public void The_fractional_result_should_be_correct_for_all_repeating_fractions(Fraction fraction,
+        int decimalPlaces, MidpointRounding roundingMode, Fraction expected) {
+        var result = Fraction.Round(fraction, decimalPlaces, roundingMode);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 
     [Test]
@@ -218,39 +202,39 @@ public class When_rounding_a_decimal_fraction : Spec {
     private static IEnumerable RoundNaNTestCases =>
         from decimalPlaces in DecimalPlaces
         from midpointRounding in RoundingModes
-        select new TestCaseData(Fraction.NaN, decimalPlaces, midpointRounding)
-            .Returns(Fraction.NaN);
+        select new TestCaseData(Fraction.NaN, decimalPlaces, midpointRounding, Fraction.NaN);
 
     [Test]
     [TestCaseSource(nameof(RoundNaNTestCases))]
-    public Fraction The_result_of_rounding_NaN_should_be_NaN(Fraction fraction, int decimalPlaces,
-        MidpointRounding roundingMode) {
-        return Fraction.Round(fraction, decimalPlaces, roundingMode);
+    public void The_result_of_rounding_NaN_should_be_NaN(Fraction fraction, int decimalPlaces,
+        MidpointRounding roundingMode, Fraction expected) {
+        var result = Fraction.Round(fraction, decimalPlaces, roundingMode);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 
     private static IEnumerable RoundPositiveInfinityTestCases =>
         from decimalPlaces in DecimalPlaces
         from midpointRounding in RoundingModes
-        select new TestCaseData(Fraction.PositiveInfinity, decimalPlaces, midpointRounding)
-            .Returns(Fraction.PositiveInfinity);
+        select new TestCaseData(Fraction.PositiveInfinity, decimalPlaces, midpointRounding, Fraction.PositiveInfinity);
 
     [Test]
     [TestCaseSource(nameof(RoundPositiveInfinityTestCases))]
-    public Fraction The_result_of_rounding_PositiveInfinity_should_be_PositiveInfinity(Fraction fraction,
-        int decimalPlaces, MidpointRounding roundingMode) {
-        return Fraction.Round(fraction, decimalPlaces, roundingMode);
+    public void The_result_of_rounding_PositiveInfinity_should_be_PositiveInfinity(Fraction fraction,
+        int decimalPlaces, MidpointRounding roundingMode, Fraction expected) {
+        var result = Fraction.Round(fraction, decimalPlaces, roundingMode);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 
     private static IEnumerable RoundNegativeInfinityTestCases =>
         from decimalPlaces in DecimalPlaces
         from midpointRounding in RoundingModes
-        select new TestCaseData(Fraction.NegativeInfinity, decimalPlaces, midpointRounding)
-            .Returns(Fraction.NegativeInfinity);
+        select new TestCaseData(Fraction.NegativeInfinity, decimalPlaces, midpointRounding, Fraction.NegativeInfinity);
 
     [Test]
     [TestCaseSource(nameof(RoundNegativeInfinityTestCases))]
-    public Fraction The_result_of_rounding_NegativeInfinity_should_be_NegativeInfinity(Fraction fraction,
-        int decimalPlaces, MidpointRounding roundingMode) {
-        return Fraction.Round(fraction, decimalPlaces, roundingMode);
+    public void The_result_of_rounding_NegativeInfinity_should_be_NegativeInfinity(Fraction fraction,
+        int decimalPlaces, MidpointRounding roundingMode, Fraction expected) {
+        var result = Fraction.Round(fraction, decimalPlaces, roundingMode);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/Sqrt/Method_Sqrt.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Sqrt/Method_Sqrt.cs
@@ -16,7 +16,11 @@ public class If_the_Sqrt_function_is_called : Spec {
 
     [Test]
     public void The_square_root_of_minus_one_should_return_NaN() {
-        Fraction.MinusOne.Sqrt().Should().Be(Fraction.NaN, "Cannot calculate square root from a negative number");
+        var result = Fraction.MinusOne.Sqrt();
+        ((object)result).Should().Be(
+            expected: Fraction.NaN,
+            comparer: StrictTestComparer.Instance,
+            because: "Cannot calculate square root from a negative number");
     }
 
     private static IEnumerable<TestCaseData> TestCases {

--- a/tests/Fractions.Tests/FractionSpecs/Subtract/Method_Subtract.cs
+++ b/tests/Fractions.Tests/FractionSpecs/Subtract/Method_Subtract.cs
@@ -103,38 +103,39 @@ public class When_subtracting_with_NaN {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // NaN with NaN
-            yield return new TestCaseData(Fraction.NaN, Fraction.NaN).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NaN, Fraction.NaN);
 
             // NaN with any number
-            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(5, 4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, -5, false)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.One).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(4, 5)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.Zero).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, 4)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(-4, 5)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, new Fraction(5, -5, false)).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(5, 4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, -5, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.One, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(4, 5), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.Zero, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.MinusOne, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-5, 4), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(-4, 5), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, new Fraction(5, -5, false), Fraction.NaN);
+            yield return new TestCaseData(Fraction.NaN, Fraction.NegativeInfinity, Fraction.NaN);
 
             // Any number with NaN
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.One, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.Zero, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN).Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN).Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(5, 4), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.One, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(4, 5), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.Zero, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.MinusOne, Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-5, 4), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(new Fraction(-4, 5), Fraction.NaN, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NaN, Fraction.NaN);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_is_always_NaN(Fraction a, Fraction b) {
-        return a.Subtract(b);
+    public void The_result_is_always_NaN(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Subtract(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
 }
 
@@ -143,60 +144,41 @@ public class When_subtracting_with_infinity {
     private static IEnumerable<TestCaseData> TestCases {
         get {
             // positive infinity with positive infinity
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 0, false), Fraction.NaN);
 
             // positive infinity with any other number
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 4))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4, 5))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 4))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4, 5))
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(5, 4), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.One, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(4, 5), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.Zero, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.MinusOne, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 4), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-4, 5), Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.NegativeInfinity, Fraction.PositiveInfinity);
+            yield return new TestCaseData(Fraction.PositiveInfinity, new Fraction(-5, 0, false), Fraction.PositiveInfinity);
 
             // negative infinity with negative infinity
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity)
-                .Returns(Fraction.NaN);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false))
-                .Returns(Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity, Fraction.NaN);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 0, false), Fraction.NaN);
 
             // negative infinity with any other number
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 4))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4, 5))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 4))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4, 5))
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity)
-                .Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 0, false))
-                .Returns(Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 4), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.One, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(4, 5), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.Zero, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.MinusOne, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-5, 4), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(-4, 5), Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.PositiveInfinity, Fraction.NegativeInfinity);
+            yield return new TestCaseData(Fraction.NegativeInfinity, new Fraction(5, 0, false), Fraction.NegativeInfinity);
         }
     }
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public Fraction The_result_is_always_NaN_or_Infinity(Fraction a, Fraction b) => a.Subtract(b);
+    public void The_result_is_always_NaN_or_Infinity(Fraction a, Fraction b, Fraction expected) {
+        var result = a.Subtract(b);
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
+    }
 }

--- a/tests/Fractions.Tests/FractionSpecs/TryParse/Method_TryParse.cs
+++ b/tests/Fractions.Tests/FractionSpecs/TryParse/Method_TryParse.cs
@@ -1,65 +1,65 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
+using FluentAssertions;
 using NUnit.Framework;
-using Tests.Fractions;
 
 namespace Fractions.Tests.FractionSpecs.TryParse;
 
 [TestFixture]
-public class When_trying_to_parse_a_fraction : Spec {
+public class When_trying_to_parse_a_fraction {
     private static IEnumerable<TestCaseData> TestCases {
         get {
-            yield return new TestCaseData("1/5").Returns(new Fraction(1, 5));
-            yield return new TestCaseData("-1/-5").Returns(new Fraction(1, 5));
-            yield return new TestCaseData("+1/5").Returns(new Fraction(1, 5));
-            yield return new TestCaseData("+1/+5").Returns(new Fraction(1, 5));
-            yield return new TestCaseData("1/+5").Returns(new Fraction(1, 5));
+            yield return new TestCaseData("1/5", new Fraction(1, 5));
+            yield return new TestCaseData("-1/-5", new Fraction(1, 5));
+            yield return new TestCaseData("+1/5", new Fraction(1, 5));
+            yield return new TestCaseData("+1/+5", new Fraction(1, 5));
+            yield return new TestCaseData("1/+5", new Fraction(1, 5));
 
-            yield return new TestCaseData("123456789987654321.123456789987654321")
-                .Returns(
-                    new Fraction(
-                        numerator: BigInteger.Parse("123456789987654321123456789987654321"),
-                        denominator: BigInteger.Pow(10, 18))
-                );
+            yield return new TestCaseData("123456789987654321.123456789987654321",
+                new Fraction(
+                    numerator: BigInteger.Parse("123456789987654321123456789987654321"),
+                    denominator: BigInteger.Pow(10, 18))
+            );
 
-            yield return new TestCaseData("-123456789987654321.123456789987654321")
-                .Returns(
-                    new Fraction(
-                        numerator: BigInteger.Parse("-123456789987654321123456789987654321"),
-                        denominator: BigInteger.Pow(10, 18))
-                );
+            yield return new TestCaseData("-123456789987654321.123456789987654321",
+                new Fraction(
+                    numerator: BigInteger.Parse("-123456789987654321123456789987654321"),
+                    denominator: BigInteger.Pow(10, 18))
+            );
 
-            yield return new TestCaseData("-1.23456789987654321E-24")
-                .Returns(
-                    new Fraction(
-                        numerator: new BigInteger(-123456789987654321),
-                        denominator: BigInteger.Pow(10, 17 + 24)));
-            yield return new TestCaseData("0/1").Returns(Fraction.Zero);
-            yield return new TestCaseData("0/+10").Returns(Fraction.Zero);
-            yield return new TestCaseData("0/-10").Returns(Fraction.Zero);
-            yield return new TestCaseData("0/0").Returns(Fraction.NaN);
-            yield return new TestCaseData("1/0").Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData("+10/0").Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData("-1/0").Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData("-10/0").Returns(Fraction.NegativeInfinity);
-            yield return new TestCaseData(CultureInfo.InvariantCulture.NumberFormat.NaNSymbol).Returns(Fraction.NaN);
-            yield return new TestCaseData(CultureInfo.InvariantCulture.NumberFormat.PositiveInfinitySymbol).Returns(Fraction.PositiveInfinity);
-            yield return new TestCaseData(CultureInfo.InvariantCulture.NumberFormat.NegativeInfinitySymbol).Returns(Fraction.NegativeInfinity);
+            yield return new TestCaseData("-1.23456789987654321E-24",
+                new Fraction(
+                    numerator: new BigInteger(-123456789987654321),
+                    denominator: BigInteger.Pow(10, 17 + 24)));
+            yield return new TestCaseData("0/1", Fraction.Zero);
+            yield return new TestCaseData("0/+10", Fraction.Zero);
+            yield return new TestCaseData("0/-10", Fraction.Zero);
+            yield return new TestCaseData("0/0", Fraction.NaN);
+            yield return new TestCaseData("1/0", Fraction.PositiveInfinity);
+            yield return new TestCaseData("+10/0", Fraction.PositiveInfinity);
+            yield return new TestCaseData("-1/0", Fraction.NegativeInfinity);
+            yield return new TestCaseData("-10/0", Fraction.NegativeInfinity);
+            yield return new TestCaseData(CultureInfo.InvariantCulture.NumberFormat.NaNSymbol, Fraction.NaN);
+            yield return new TestCaseData(CultureInfo.InvariantCulture.NumberFormat.PositiveInfinitySymbol,
+                Fraction.PositiveInfinity);
+            yield return new TestCaseData(CultureInfo.InvariantCulture.NumberFormat.NegativeInfinitySymbol,
+                Fraction.NegativeInfinity);
         }
     }
 
     [Test, TestCaseSource(nameof(TestCases))]
-    public Fraction? The_result_should_be_as_expected(string value) =>
-        Fraction.TryParse(
+    public void The_result_should_be_as_expected(string value, Fraction expected) {
+        var success = Fraction.TryParse(
             value: value,
             numberStyles: NumberStyles.Number | NumberStyles.AllowExponent,
             formatProvider: CultureInfo.InvariantCulture,
             normalize: true,
-            fraction: out var result)
-            ? result
-            : default(Fraction?);
+            fraction: out var result);
+
+        success.Should().BeTrue();
+        Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
+    }
 
     // TODO see about testing the non-normalized parsing variant (see tests in Method_FromString)
 }

--- a/tests/Fractions.Tests/FractionSpecs/ValueEquals/Method_ValueEquals.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ValueEquals/Method_ValueEquals.cs
@@ -47,7 +47,6 @@ public class When_comparing_two_fractions {
 }
 
 [TestFixture]
-// German: Wenn zwei Brüche mit identischen Zähler und Nenner verglichen werden
 public class When_comparing_two_fractions_with_identical_numerator_and_denominator : Spec {
     private Fraction _fractionA;
     private Fraction _fractionB;
@@ -59,15 +58,13 @@ public class When_comparing_two_fractions_with_identical_numerator_and_denominat
     }
 
     [Test]
-    // German: Diese sollten als wertgleich erkannt werden
-    public void These_should_be_recognized_as_equivalent() {
-        _fractionA.IsEquivalentTo(_fractionB)
+    public void These_should_be_recognized_as_equal() {
+        _fractionA.Equals(_fractionB)
             .Should().BeTrue();
     }
 }
 
 [TestFixture]
-// German: Wenn zwei Brüche mit unterschiedlichen Zähler aber identischen Nenner verglichen werden
 public class When_comparing_two_fractions_with_different_numerator_but_identical_denominator : Spec {
     private Fraction _fractionA;
     private Fraction _fractionB;
@@ -79,15 +76,13 @@ public class When_comparing_two_fractions_with_different_numerator_but_identical
     }
 
     [Test]
-    // German: Diese sollten als nicht wertgleich erkannt werden
-    public void These_should_be_recognized_as_not_equivalent() {
-        _fractionA.IsEquivalentTo(_fractionB)
+    public void These_should_be_recognized_as_equal() {
+        _fractionA.Equals(_fractionB)
             .Should().BeFalse();
     }
 }
 
 [TestFixture]
-// German: Wenn zwei Brüche mit identischen Zähler aber unterschiedlichen Nenner verglichen werden
 public class When_comparing_two_fractions_with_identical_numerator_but_different_denominator : Spec {
     private Fraction _fractionA;
     private Fraction _fractionB;
@@ -99,15 +94,13 @@ public class When_comparing_two_fractions_with_identical_numerator_but_different
     }
 
     [Test]
-    // German: Diese sollten als nicht wertgleich erkannt werden
     public void These_should_be_recognized_as_not_equivalent() {
-        _fractionA.IsEquivalentTo(_fractionB)
+        _fractionA.Equals(_fractionB)
             .Should().BeFalse();
     }
 }
 
 [TestFixture]
-// German: Wenn der Bruch 2/4 mit dem Bruch 1/2 verglichen wird
 public class When_comparing_the_fraction_2_over_4_with_the_fraction_1_over_2 : Spec {
     private Fraction _fractionA;
     private Fraction _fractionB;
@@ -119,16 +112,8 @@ public class When_comparing_the_fraction_2_over_4_with_the_fraction_1_over_2 : S
     }
 
     [Test]
-    // German: Die Brüche sollten als nicht strukturell gleich erkannt werden
-    public void The_fractions_should_be_recognized_as_not_equal() {
+    public void The_fractions_should_be_recognized_as_equal() {
         _fractionA.Equals(_fractionB)
-            .Should().BeFalse();
-    }
-
-    [Test]
-    // German: Die Brüche sollten als wertgleich erkannt werden
-    public void The_fractions_should_be_recognized_as_equivalent() {
-        _fractionA.IsEquivalentTo(_fractionB)
             .Should().BeTrue();
     }
 }
@@ -162,11 +147,6 @@ public class When_comparing_NaN_with_NaN {
     public void Using_Equals_should_return_true() {
         Fraction.NaN.Equals(Fraction.NaN).Should().BeTrue("Because double.NaN.Equals(double.NaN) is true");
     }
-
-    [Test]
-    public void Using_IsEquivalent_should_return_true() {
-        Fraction.NaN.IsEquivalentTo(Fraction.NaN).Should().BeTrue("Because Fraction.NaN.Equals(Fraction.NaN) is true");
-    }
 }
 
 [TestFixture]
@@ -196,12 +176,6 @@ public class When_comparing_NaN_with_another_Fraction() {
     public void Using_Equals_should_return_false(Fraction fraction) {
         Fraction.NaN.Equals(fraction).Should().BeFalse();
     }
-
-    [Test]
-    [TestCaseSource(nameof(TestCases))]
-    public void Using_IsEquivalent_should_return_false(Fraction fraction) {
-        Fraction.NaN.IsEquivalentTo(fraction).Should().BeFalse();
-    }
 }
 
 [TestFixture]
@@ -224,12 +198,6 @@ public class When_comparing_PositiveInfinity_with_PositiveInfinity {
     public void Using_Equals_should_return_true() {
         Fraction.PositiveInfinity.Equals(Fraction.PositiveInfinity).Should()
             .BeTrue("Because double.PositiveInfinity.Equals(double.PositiveInfinity) is true");
-    }
-
-    [Test]
-    public void Using_IsEquivalent_should_return_true() {
-        Fraction.PositiveInfinity.IsEquivalentTo(Fraction.PositiveInfinity).Should()
-            .BeTrue("Because Fraction.PositiveInfinity.Equals(Fraction.PositiveInfinity) is true");
     }
 }
 
@@ -256,17 +224,9 @@ public class When_comparing_PositiveInfinity_with_a_4_over_0 {
     }
 
     [Test]
-    public void Using_Equals_should_return_false() {
-        Fraction.PositiveInfinity.Equals(NonReducedInfinity).Should()
-            .BeFalse("Because this is the result of (a/b).Equals((a*c, b*c))");
-        NonReducedInfinity.Equals(Fraction.PositiveInfinity).Should()
-            .BeFalse("Because this is the result of ((a*c, b*c)).Equals(a/b)");
-    }
-
-    [Test]
-    public void Using_IsEquivalent_should_return_true() {
-        Fraction.PositiveInfinity.IsEquivalentTo(NonReducedInfinity).Should().BeTrue("Because 3/0 reduces to 1/0");
-        NonReducedInfinity.IsEquivalentTo(Fraction.PositiveInfinity).Should().BeTrue("Because 3/0 reduces to 1/0");
+    public void Using_Equals_should_return_true() {
+        Fraction.PositiveInfinity.Equals(NonReducedInfinity).Should().BeTrue("Because 3/0 reduces to 1/0");
+        NonReducedInfinity.Equals(Fraction.PositiveInfinity).Should().BeTrue("Because 3/0 reduces to 1/0");
     }
 }
 
@@ -306,13 +266,6 @@ public class When_comparing_PositiveInfinity_with_another_Fraction() {
         Fraction.PositiveInfinity.Equals(fraction).Should().BeFalse();
         fraction.Equals(Fraction.PositiveInfinity).Should().BeFalse();
     }
-
-    [Test]
-    [TestCaseSource(nameof(UnequalFractionCases))]
-    public void Comparing_NaN_with_NaN_using_IsEquivalent_should_return_false(Fraction fraction) {
-        Fraction.PositiveInfinity.IsEquivalentTo(fraction).Should().BeFalse();
-        fraction.IsEquivalentTo(Fraction.PositiveInfinity).Should().BeFalse();
-    }
 }
 
 [TestFixture]
@@ -335,12 +288,6 @@ public class When_comparing_NegativeInfinity_with_NegativeInfinity {
     public void Using_Equals_should_return_true() {
         Fraction.NegativeInfinity.Equals(Fraction.NegativeInfinity).Should()
             .BeTrue("Because double.NegativeInfinity.Equals(double.NegativeInfinity) is true");
-    }
-
-    [Test]
-    public void Using_IsEquivalent_should_return_true() {
-        Fraction.NegativeInfinity.IsEquivalentTo(Fraction.NegativeInfinity).Should()
-            .BeTrue("Because Fraction.NegativeInfinity.Equals(Fraction.NegativeInfinity) is true");
     }
 }
 
@@ -367,17 +314,9 @@ public class When_comparing_NegativeInfinity_with_a_minus_4_over_0 {
     }
 
     [Test]
-    public void Using_Equals_should_return_false() {
-        Fraction.NegativeInfinity.Equals(NonReducedInfinity).Should()
-            .BeFalse("Because this is the result of (a/b).Equals((a*c, b*c))");
-        NonReducedInfinity.Equals(Fraction.NegativeInfinity).Should()
-            .BeFalse("Because this is the result of ((a*c, b*c)).Equals(a/b)");
-    }
-
-    [Test]
-    public void Using_IsEquivalent_should_return_true() {
-        Fraction.NegativeInfinity.IsEquivalentTo(NonReducedInfinity).Should().BeTrue("Because -3/0 reduces to -1/0");
-        NonReducedInfinity.IsEquivalentTo(Fraction.NegativeInfinity).Should().BeTrue("Because -3/0 reduces to -1/0");
+    public void Using_Equals_should_return_true() {
+        Fraction.NegativeInfinity.Equals(NonReducedInfinity).Should().BeTrue("Because -3/0 reduces to -1/0");
+        NonReducedInfinity.Equals(Fraction.NegativeInfinity).Should().BeTrue("Because -3/0 reduces to -1/0");
     }
 }
 
@@ -420,8 +359,8 @@ public class When_comparing_NegativeInfinity_with_another_Fraction() {
 
     [Test]
     [TestCaseSource(nameof(UnequalFractionCases))]
-    public void Comparing_NaN_with_NaN_using_IsEquivalent_should_return_false(Fraction fraction) {
-        Fraction.NegativeInfinity.IsEquivalentTo(fraction).Should().BeFalse();
-        fraction.IsEquivalentTo(Fraction.NegativeInfinity).Should().BeFalse();
+    public void Comparing_NaN_with_NaN_using_Equals_should_return_false(Fraction fraction) {
+        Fraction.NegativeInfinity.Equals(fraction).Should().BeFalse();
+        fraction.Equals(Fraction.NegativeInfinity).Should().BeFalse();
     }
 }

--- a/tests/Fractions.Tests/FractionSpecs/ValueEquals/Method_ValueEquals.cs
+++ b/tests/Fractions.Tests/FractionSpecs/ValueEquals/Method_ValueEquals.cs
@@ -28,12 +28,12 @@ public class When_comparing_two_fractions {
             yield return new TestCaseData(Fraction.PositiveInfinity, Fraction.PositiveInfinity).Returns(true);
             yield return new TestCaseData(Fraction.NegativeInfinity, Fraction.NegativeInfinity).Returns(true);
             yield return new TestCaseData(new Fraction(0, 1, normalize: false), Fraction.Zero).Returns(true);
+            // special -> not normalized fraction
+            yield return new TestCaseData(new Fraction(0, 2, normalize: false), Fraction.Zero).Returns(true);
 
             // not equal
             yield return new TestCaseData(Fraction.One, Fraction.Zero).Returns(false);
             yield return new TestCaseData(Fraction.One, Fraction.NaN).Returns(false);
-            // special -> not normalized fraction
-            yield return new TestCaseData(new Fraction(0, 2, normalize: false), Fraction.Zero).Returns(false);
         }
     }
 
@@ -207,20 +207,20 @@ public class When_comparing_PositiveInfinity_with_a_4_over_0 {
 
     [Test]
     [SuppressMessage("ReSharper", "EqualExpressionComparison")]
-    public void Using_the_equality_operator_should_return_false() {
+    public void Using_the_equality_operator_should_return_true() {
         (Fraction.PositiveInfinity == NonReducedInfinity).Should()
-            .BeFalse("Because this is the result of a/b == (a*c)/(b*c)");
+            .BeTrue("Because this is the result of a/b == (a*c)/(b*c)");
         (NonReducedInfinity == Fraction.PositiveInfinity).Should()
-            .BeFalse("Because this is the result of (a*c)/(b*c) == a/b");
+            .BeTrue("Because this is the result of (a*c)/(b*c) == a/b");
     }
 
     [Test]
     [SuppressMessage("ReSharper", "EqualExpressionComparison")]
-    public void Using_the_non_equality_operator_should_return_true() {
+    public void Using_the_non_equality_operator_should_return_false() {
         (Fraction.PositiveInfinity != NonReducedInfinity).Should()
-            .BeTrue("Because this is the result of a/b != (a*c)/(b*c)");
+            .BeFalse("Because this is the result of a/b != (a*c)/(b*c)");
         (NonReducedInfinity != Fraction.PositiveInfinity).Should()
-            .BeTrue("Because this is the result of (a*c)/(b*c) != a/b");
+            .BeFalse("Because this is the result of (a*c)/(b*c) != a/b");
     }
 
     [Test]
@@ -297,20 +297,20 @@ public class When_comparing_NegativeInfinity_with_a_minus_4_over_0 {
 
     [Test]
     [SuppressMessage("ReSharper", "EqualExpressionComparison")]
-    public void Using_the_equality_operator_should_return_false() {
+    public void Using_the_equality_operator_should_return_true() {
         (Fraction.NegativeInfinity == NonReducedInfinity).Should()
-            .BeFalse("Because this is the result of a/b == (a*c)/(b*c)");
+            .BeTrue("Because this is the result of a/b == (a*c)/(b*c)");
         (NonReducedInfinity == Fraction.NegativeInfinity).Should()
-            .BeFalse("Because this is the result of (a*c)/(b*c) == a/b");
+            .BeTrue("Because this is the result of (a*c)/(b*c) == a/b");
     }
 
     [Test]
     [SuppressMessage("ReSharper", "EqualExpressionComparison")]
-    public void Using_the_non_equality_operator_should_return_true() {
+    public void Using_the_non_equality_operator_should_return_false() {
         (Fraction.NegativeInfinity != NonReducedInfinity).Should()
-            .BeTrue("Because this is the result of a/b != (a*c)/(b*c)");
+            .BeFalse("Because this is the result of a/b != (a*c)/(b*c)");
         (NonReducedInfinity != Fraction.NegativeInfinity).Should()
-            .BeTrue("Because this is the result of (a*c)/(b*c) != a/b");
+            .BeFalse("Because this is the result of (a*c)/(b*c) != a/b");
     }
 
     [Test]

--- a/tests/Fractions.Tests/StrictTestComparer.cs
+++ b/tests/Fractions.Tests/StrictTestComparer.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Fractions.Tests;
+
+/// <summary>
+/// An equality comparer that checks if two <see cref="Fraction"/> values are exactly the same.
+/// </summary>
+internal sealed class StrictTestComparer : IEqualityComparer<Fraction>, IEqualityComparer {
+    public static IEqualityComparer<Fraction> Instance { get; } = new StrictTestComparer();
+
+    public bool Equals(Fraction x, Fraction y) =>
+        x.Numerator == y.Numerator &&
+        x.Denominator == y.Denominator &&
+        x.State == y.State;
+
+    public int GetHashCode(Fraction obj) {
+        unchecked {
+            return (((obj.Denominator.GetHashCode() * 397) ^ obj.Numerator.GetHashCode()) * 397) ^
+                   obj.State.GetHashCode();
+        }
+    }
+
+    bool IEqualityComparer.Equals(object x, object y) => Equals(x, y);
+
+    public new bool Equals(object x, object y) {
+        if (ReferenceEquals(x, y)) {
+            return true;
+        }
+
+        if (x is null || y is null) {
+            return false;
+        }
+
+        return x is Fraction a &&
+               y is Fraction b &&
+               Equals(a, b);
+    }
+
+    public int GetHashCode(object obj) {
+        if (obj is null) {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        return obj is Fraction fraction
+            ? GetHashCode(fraction)
+            : obj.GetHashCode();
+    }
+}


### PR DESCRIPTION
This pull request introduces a breaking change. The `Equals(..)` method and the `==`, `!=` operators now checks for equality of values.

- [x] New base class `FractionComparer` that implements  `IEqualityComparer<Fraction>`, `IEqualityComparer`
- [x] New class `FractionValueEqualityComparer` (that checks for value equality)
- [x] Data type `Fraction` uses `FractionComparer.ValueEquality` for `Equals(..)` and `GetHashCode()`
- [x] Changed (some) unit tests to use a strict equality check
- [x] New class `FractionStrictEqualityComparer` (that checks the exact values of _numerator_ and _denominator_)
