### PR TITLE
Fixes #76 - CS8604 Possible null reference argument for parameter 'value' in 'bool Fraction.TryParse

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 8.0.1
+
+- Fixed nullable issue in Fraction.TryParse(..) reported in https://github.com/danm-de/Fractions/issues/76
+  Error (active) CS8604 Possible null reference argument for parameter 'value' in 'bool Fraction.TryParse(..)
+
 ## 8.0.0
 
 - Added support for NaN and Infinity by https://github.com/lipchev

--- a/src/Fractions.Json/Fractions.Json.csproj
+++ b/src/Fractions.Json/Fractions.Json.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>fraction math</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../Fractions.snk</AssemblyOriginatorKeyFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Fractions/Fraction.TryParse.cs
+++ b/src/Fractions/Fraction.TryParse.cs
@@ -1,8 +1,10 @@
 ﻿#nullable enable
 
+#if !NET
+using System.Linq;
+#endif
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Numerics;
 
 namespace Fractions;
@@ -43,7 +45,7 @@ public readonly partial struct Fraction {
     ///         a denominator of 10000.
     ///     </example>
     /// </remarks>
-    public static bool TryParse(string value, out Fraction fraction) =>
+    public static bool TryParse(string? value, out Fraction fraction) =>
         TryParse(
             value: value,
             numberStyles: NumberStyles.Number,
@@ -101,7 +103,7 @@ public readonly partial struct Fraction {
     ///         </example>
     ///     </para>
     /// </remarks>
-    public static bool TryParse(string value, NumberStyles numberStyles, IFormatProvider? formatProvider,
+    public static bool TryParse(string? value, NumberStyles numberStyles, IFormatProvider? formatProvider,
         out Fraction fraction) {
         return TryParse(value, numberStyles, formatProvider, true, out fraction);
     }
@@ -168,7 +170,7 @@ public readonly partial struct Fraction {
     ///         </example>
     ///     </para>
     /// </remarks>
-    public static bool TryParse(string value, NumberStyles numberStyles, IFormatProvider? formatProvider,
+    public static bool TryParse(string? value, NumberStyles numberStyles, IFormatProvider? formatProvider,
         bool normalize, out Fraction fraction) {
         return TryParse(value.AsSpan(), numberStyles, formatProvider, normalize, out fraction);
     }
@@ -798,13 +800,13 @@ public readonly partial struct Fraction {
     ///         denominator of 10000.
     ///     </example>
     /// </remarks>
-    public static bool TryParse(string value, NumberStyles numberStyles, IFormatProvider? formatProvider,
+    public static bool TryParse(string? value, NumberStyles numberStyles, IFormatProvider? formatProvider,
         bool normalize, out Fraction fraction) {
         if (string.IsNullOrWhiteSpace(value)) {
             return CannotParse(out fraction);
         }
 
-        if (value.Length == 1) {
+        if (value!.Length == 1) {
             if (!BigInteger.TryParse(value, numberStyles, formatProvider, out var singleDigit)) {
                 return CannotParse(out fraction);
             }

--- a/src/Fractions/Fractions.csproj
+++ b/src/Fractions/Fractions.csproj
@@ -13,7 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>fraction math</PackageTags>
     <Description>The fraction data type consists of two BigInteger values for numerator and denominator. It implements various operations (addition, subtraction, multiplication, division and remainder) with operator overloads.</Description>
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../Fractions.snk</AssemblyOriginatorKeyFile>
@@ -28,6 +28,21 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReleaseNotes>8.0.0
+- Added support for NaN and Infinity by https://github.com/lipchev
+- New properties IsNaN, IsInfinity, IsPositiveInfinity, IsNegativeInfinity by https://github.com/lipchev
+- Adding a debugger display proxy by https://github.com/lipchev
+- Various methods were optimized by https://github.com/lipchev
+- Use the potential of Span&lt;T&gt; where sensible and possible (TryParse, FromDecimal) by https://github.com/lipchev
+- No longer reduce non-normalized fractions when used in mathematical operations - by https://github.com/lipchev
+
+Breaking changes
+
+- Mathematical operations no longer automatically generate normalized fractions if one of the operands is an non-normalized fraction. This has an impact on your calculations, especially if you have used the JsonFractionConverter with default settings. In such cases, deserialized fractions create non-normalized fractions, which can lead to changed behavior when calling ToString. Please refer the README section Working with non-normalized fractions
+- The default behavior of the .Equals(Fraction) method has changed: Equals now compares the calculated value from the numerator/denominator (1/2 = 2/4).
+- The standard function ToString() now depends on the active culture (CultureInfo.CurrentCulture). The reason is that NaN and Infinity should be displayed in the system language or the corresponding symbol should be used.
+- Argument name for Fraction.TryParse(..) changed from fractionString to value.
+- A fraction of 0/0 no longer has the value 0, but means NaN (not a number). Any fraction in the form x/0 is no longer a valid number. A denominator with the value 0 corresponds to, depending on the numerator, NaN, PositiveInfinity or NegativeInfinity.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Fractions.Tests/FractionSpecs/TryParse/Method_TryParse.cs
+++ b/tests/Fractions.Tests/FractionSpecs/TryParse/Method_TryParse.cs
@@ -60,6 +60,23 @@ public class When_trying_to_parse_a_fraction {
         success.Should().BeTrue();
         Assert.That(result, Is.EqualTo(expected).Using(StrictTestComparer.Instance));
     }
-
     // TODO see about testing the non-normalized parsing variant (see tests in Method_FromString)
+}
+
+[TestFixture]
+public class When_trying_to_parse_an_invalid_fraction {
+
+    private static IEnumerable<TestCaseData> TestCases {
+        get {
+            yield return new TestCaseData("FOOBAR");
+            yield return new TestCaseData(string.Empty);
+            yield return new TestCaseData(" ");
+            yield return new TestCaseData(default(string));
+            yield return new TestCaseData("abc123");
+        }
+    }
+
+    [Test, TestCaseSource(nameof(TestCases))]
+    public void The_result_should_be_FALSE(string value) =>
+        Fraction.TryParse(value, out _).Should().BeFalse();
 }


### PR DESCRIPTION
Fixed nullable issue in Fraction.TryParse(..) reported in https://github.com/danm-de/Fractions/issues/76

Error (active) CS8604 Possible null reference argument for parameter 'value' in 'bool Fraction.TryParse(..)