### PR TITLE
Optimizing the FromDoubleRounded (with significant digits)

### DIFF
--- a/benchmarks/Fractions.Benchmarks/FromDoubleBenchmarks.cs
+++ b/benchmarks/Fractions.Benchmarks/FromDoubleBenchmarks.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Attributes;
 namespace Fractions.Benchmarks;
 
 [MemoryDiagnoser]
+[ShortRunJob]
 public class FromDoubleBenchmarks {
     public FromDoubleBenchmarks() {
         // initialize static
@@ -28,27 +29,30 @@ public class FromDoubleBenchmarks {
         Math.PI
     ];
 
+    [Params(true, false)]
+    public bool ReduceTerms { get; set; }
+
     [Benchmark]
     [ArgumentsSource(nameof(DoubleValues))]
     public Fraction Construct_FromDouble(double value) {
-        return Fraction.FromDouble(value);
+        return Fraction.FromDouble(value, ReduceTerms);
     }
 
     [Benchmark]
     [ArgumentsSource(nameof(DoubleValues))]
     public Fraction Construct_FromDoubleRounded(double value) {
-        return Fraction.FromDoubleRounded(value);
+        return Fraction.FromDoubleRounded(value, ReduceTerms);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(DoubleValues))]
+    public Fraction Construct_FromDoubleRoundedToEightDigits(double value) {
+        return Fraction.FromDoubleRounded(value, 8, ReduceTerms);
     }
 
     [Benchmark]
     [ArgumentsSource(nameof(DoubleValues))]
     public Fraction Construct_FromDoubleRoundedToFifteenDigits(double value) {
-        return Fraction.FromDoubleRounded(value, 15);
-    }
-
-    [Benchmark]
-    [ArgumentsSource(nameof(DoubleValues))]
-    public Fraction Construct_FromDoubleRoundedToEighteenDigits(double value) {
-        return Fraction.FromDoubleRounded(value, 18);
+        return Fraction.FromDoubleRounded(value, 15, ReduceTerms);
     }
 }

--- a/benchmarks/results/Fractions.Benchmarks.FromDoubleBenchmarks-report-github.md
+++ b/benchmarks/results/Fractions.Benchmarks.FromDoubleBenchmarks-report-github.md
@@ -1,80 +1,150 @@
 ```
 
-BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4291/22H2/2022Update)
+BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4529/22H2/2022Update)
 AMD Ryzen 9 7900X, 1 CPU, 24 logical and 12 physical cores
-.NET SDK 8.0.204
-  [Host]     : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
-  DefaultJob : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+.NET SDK 8.0.302
+  [Host]   : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
+  ShortRun : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
 
+Job=ShortRun  IterationCount=3  LaunchCount=1  
+WarmupCount=3  
 
 ```
-| Method                                      | value                | Mean       | Error      | StdDev     | Gen0   | Allocated |
-|-------------------------------------------- |--------------------- |-----------:|-----------:|-----------:|-------:|----------:|
-| **Construct_FromDouble**                        | **NaN**                  |   **8.381 ns** |  **0.0597 ns** |  **0.0558 ns** |      **-** |         **-** |
-| Construct_FromDoubleRounded                 | NaN                  |   6.981 ns |  0.0384 ns |  0.0359 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | NaN                  |   7.707 ns |  0.0518 ns |  0.0484 ns |      - |         - |
-| Construct_FromDoubleRoundedToEighteenDigits | NaN                  |   7.697 ns |  0.0626 ns |  0.0586 ns |      - |         - |
-| **Construct_FromDouble**                        | **-Infinity**            |   **8.399 ns** |  **0.0588 ns** |  **0.0550 ns** |      **-** |         **-** |
-| Construct_FromDoubleRounded                 | -Infinity            |   6.941 ns |  0.0387 ns |  0.0362 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | -Infinity            |   8.063 ns |  0.0442 ns |  0.0413 ns |      - |         - |
-| Construct_FromDoubleRoundedToEighteenDigits | -Infinity            |   8.080 ns |  0.0437 ns |  0.0408 ns |      - |         - |
-| **Construct_FromDouble**                        | **-7.92(...)4E+28 [22]** | **129.805 ns** |  **1.2395 ns** |  **1.1594 ns** | **0.0105** |     **176 B** |
-| Construct_FromDoubleRounded                 | -7.92(...)4E+28 [22] |  21.166 ns |  0.1416 ns |  0.1324 ns | 0.0024 |      40 B |
-| Construct_FromDoubleRoundedToFifteenDigits  | -7.92(...)4E+28 [22] | 126.813 ns |  0.9539 ns |  0.8456 ns | 0.0062 |     104 B |
-| Construct_FromDoubleRoundedToEighteenDigits | -7.92(...)4E+28 [22] | 119.256 ns |  0.7875 ns |  0.6981 ns | 0.0062 |     104 B |
-| **Construct_FromDouble**                        | **-0.02702702702702703** | **142.208 ns** |  **1.3240 ns** |  **1.2385 ns** | **0.0114** |     **192 B** |
-| Construct_FromDoubleRounded                 | -0.02702702702702703 |  20.145 ns |  0.4113 ns |  0.5051 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | -0.02702702702702703 | 165.791 ns |  0.8773 ns |  0.8206 ns | 0.0095 |     160 B |
-| Construct_FromDoubleRoundedToEighteenDigits | -0.02702702702702703 | 176.689 ns |  1.2235 ns |  1.1445 ns | 0.0095 |     160 B |
-| **Construct_FromDouble**                        | **-3.69(...)7E-06 [23]** | **158.954 ns** |  **0.7100 ns** |  **0.6641 ns** | **0.0081** |     **136 B** |
-| Construct_FromDoubleRounded                 | -3.69(...)7E-06 [23] |  81.987 ns |  0.4051 ns |  0.3591 ns | 0.0019 |      32 B |
-| Construct_FromDoubleRoundedToFifteenDigits  | -3.69(...)7E-06 [23] | 188.329 ns |  1.3635 ns |  1.2754 ns | 0.0081 |     136 B |
-| Construct_FromDoubleRoundedToEighteenDigits | -3.69(...)7E-06 [23] | 203.500 ns |  1.3094 ns |  1.2248 ns | 0.0081 |     136 B |
-| **Construct_FromDouble**                        | **0**                    |   **7.975 ns** |  **0.0449 ns** |  **0.0420 ns** |      **-** |         **-** |
-| Construct_FromDoubleRounded                 | 0                    |   7.317 ns |  0.0455 ns |  0.0426 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 0                    |   7.310 ns |  0.0455 ns |  0.0404 ns |      - |         - |
-| Construct_FromDoubleRoundedToEighteenDigits | 0                    |   7.323 ns |  0.0393 ns |  0.0348 ns |      - |         - |
-| **Construct_FromDouble**                        | **0.022046226218487758** | **233.104 ns** |  **0.9541 ns** |  **0.8457 ns** | **0.0114** |     **192 B** |
-| Construct_FromDoubleRounded                 | 0.022046226218487758 | 214.339 ns |  0.8105 ns |  0.7581 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 0.022046226218487758 | 204.963 ns |  1.3935 ns |  1.3035 ns | 0.0095 |     160 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 0.022046226218487758 | 231.901 ns |  1.2852 ns |  1.2022 ns | 0.0095 |     160 B |
-| **Construct_FromDouble**                        | **0.09999999999999999**  | **113.169 ns** |  **0.7783 ns** |  **0.7280 ns** | **0.0076** |     **128 B** |
-| Construct_FromDoubleRounded                 | 0.09999999999999999  |  23.182 ns |  0.1320 ns |  0.1235 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 0.09999999999999999  | 185.452 ns |  0.7693 ns |  0.7196 ns | 0.0076 |     128 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 0.09999999999999999  | 184.663 ns |  1.5667 ns |  1.4655 ns | 0.0095 |     160 B |
-| **Construct_FromDouble**                        | **0.3333333333333333**   | **118.222 ns** |  **0.8499 ns** |  **0.7534 ns** | **0.0076** |     **128 B** |
-| Construct_FromDoubleRounded                 | 0.3333333333333333   |  23.103 ns |  0.1009 ns |  0.0944 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 0.3333333333333333   | 153.353 ns |  1.1191 ns |  1.0468 ns | 0.0057 |      96 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 0.3333333333333333   | 166.299 ns |  0.9816 ns |  0.8701 ns | 0.0095 |     160 B |
-| **Construct_FromDouble**                        | **1.345**                | **123.921 ns** |  **0.6137 ns** |  **0.5441 ns** | **0.0076** |     **128 B** |
-| Construct_FromDoubleRounded                 | 1.345                |  66.999 ns |  0.2545 ns |  0.2380 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 1.345                | 185.682 ns |  0.7600 ns |  0.7109 ns | 0.0095 |     160 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 1.345                | 189.569 ns |  1.5315 ns |  1.4326 ns | 0.0114 |     192 B |
-| **Construct_FromDouble**                        | **3.141592653589793**    | **235.911 ns** |  **0.8411 ns** |  **0.7456 ns** | **0.0153** |     **256 B** |
-| Construct_FromDoubleRounded                 | 3.141592653589793    | 152.289 ns |  0.6220 ns |  0.5818 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 3.141592653589793    | 194.398 ns |  1.4376 ns |  1.3448 ns | 0.0076 |     128 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 3.141592653589793    | 208.037 ns |  1.3150 ns |  1.2301 ns | 0.0114 |     192 B |
-| **Construct_FromDouble**                        | **42**                   | **118.938 ns** |  **1.0274 ns** |  **0.9611 ns** | **0.0057** |      **96 B** |
-| Construct_FromDoubleRounded                 | 42                   |  17.372 ns |  0.0685 ns |  0.0640 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | 42                   |  40.168 ns |  0.1353 ns |  0.1266 ns |      - |         - |
-| Construct_FromDoubleRoundedToEighteenDigits | 42                   |  40.095 ns |  0.1009 ns |  0.0842 ns |      - |         - |
-| **Construct_FromDouble**                        | **2110.11170524**        | **183.860 ns** |  **0.9717 ns** |  **0.9089 ns** | **0.0114** |     **192 B** |
-| Construct_FromDoubleRounded                 | 2110.11170524        | 166.126 ns |  0.2413 ns |  0.1884 ns | 0.0019 |      32 B |
-| Construct_FromDoubleRoundedToFifteenDigits  | 2110.11170524        | 185.095 ns |  1.3864 ns |  1.2969 ns | 0.0095 |     160 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 2110.11170524        | 200.376 ns |  1.2332 ns |  1.1535 ns | 0.0076 |     128 B |
-| **Construct_FromDouble**                        | **1024000000000**        | **157.300 ns** |  **1.2685 ns** |  **1.1866 ns** | **0.0114** |     **192 B** |
-| Construct_FromDoubleRounded                 | 1024000000000        |  24.067 ns |  0.1242 ns |  0.1162 ns | 0.0019 |      32 B |
-| Construct_FromDoubleRoundedToFifteenDigits  | 1024000000000        |  45.356 ns |  0.2548 ns |  0.2383 ns | 0.0019 |      32 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 1024000000000        |  45.727 ns |  0.1742 ns |  0.1630 ns | 0.0019 |      32 B |
-| **Construct_FromDouble**                        | **5.9722E+24**           | **222.129 ns** |  **1.6255 ns** |  **1.5205 ns** | **0.0153** |     **256 B** |
-| Construct_FromDoubleRounded                 | 5.9722E+24           |  27.822 ns |  0.1782 ns |  0.1580 ns | 0.0024 |      40 B |
-| Construct_FromDoubleRoundedToFifteenDigits  | 5.9722E+24           | 108.333 ns |  0.6975 ns |  0.6524 ns | 0.0043 |      72 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 5.9722E+24           |  96.052 ns |  0.6264 ns |  0.5860 ns | 0.0043 |      72 B |
-| **Construct_FromDouble**                        | **1.797(...)E+308 [23]** | **362.049 ns** |  **2.4876 ns** |  **2.3269 ns** | **0.0353** |     **592 B** |
-| Construct_FromDoubleRounded                 | 1.797(...)E+308 [23] |  91.855 ns |  0.4265 ns |  0.3990 ns | 0.0091 |     152 B |
-| Construct_FromDoubleRoundedToFifteenDigits  | 1.797(...)E+308 [23] | 665.498 ns | 12.7927 ns | 14.2191 ns | 0.0200 |     336 B |
-| Construct_FromDoubleRoundedToEighteenDigits | 1.797(...)E+308 [23] | 657.372 ns | 13.1736 ns | 18.0322 ns | 0.0200 |     336 B |
-| **Construct_FromDouble**                        | **Infinity**             |   **8.377 ns** |  **0.0611 ns** |  **0.0572 ns** |      **-** |         **-** |
-| Construct_FromDoubleRounded                 | Infinity             |   6.759 ns |  0.0400 ns |  0.0374 ns |      - |         - |
-| Construct_FromDoubleRoundedToFifteenDigits  | Infinity             |   7.878 ns |  0.0551 ns |  0.0516 ns |      - |         - |
-| Construct_FromDoubleRoundedToEighteenDigits | Infinity             |   7.879 ns |  0.0495 ns |  0.0463 ns |      - |         - |
+| Method                                     | ReduceTerms | value                | Mean       | Error       | StdDev     | Gen0   | Allocated |
+|------------------------------------------- |------------ |--------------------- |-----------:|------------:|-----------:|-------:|----------:|
+| **Construct_FromDouble**                       | **False**       | **NaN**                  |  **11.039 ns** |   **0.9945 ns** |  **0.0545 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | False       | NaN                  |   3.960 ns |   0.2487 ns |  0.0136 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | NaN                  |   4.731 ns |   0.3155 ns |  0.0173 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | NaN                  |   4.719 ns |   0.4605 ns |  0.0252 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **-Infinity**            |  **11.006 ns** |   **1.3336 ns** |  **0.0731 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | False       | -Infinity            |   3.808 ns |   0.0774 ns |  0.0042 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | -Infinity            |   4.994 ns |   0.8210 ns |  0.0450 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | -Infinity            |   4.914 ns |   0.2096 ns |  0.0115 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **-7.92(...)4E+28 [22]** |  **68.291 ns** |  **22.3690 ns** |  **1.2261 ns** | **0.0091** |     **152 B** |
+| Construct_FromDoubleRounded                | False       | -7.92(...)4E+28 [22] |  10.191 ns |   1.2552 ns |  0.0688 ns | 0.0024 |      40 B |
+| Construct_FromDoubleRoundedToEightDigits   | False       | -7.92(...)4E+28 [22] | 130.307 ns |  23.0188 ns |  1.2617 ns | 0.0048 |      80 B |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | -7.92(...)4E+28 [22] | 124.487 ns |  13.7018 ns |  0.7510 ns | 0.0062 |     104 B |
+| **Construct_FromDouble**                       | **False**       | **-0.02702702702702703** |  **49.533 ns** |   **4.2151 ns** |  **0.2310 ns** | **0.0076** |     **128 B** |
+| Construct_FromDoubleRounded                | False       | -0.02702702702702703 |   9.754 ns |   1.0502 ns |  0.0576 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | -0.02702702702702703 |  91.909 ns |   7.2086 ns |  0.3951 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | -0.02702702702702703 | 115.456 ns |   8.2672 ns |  0.4532 ns | 0.0038 |      64 B |
+| **Construct_FromDouble**                       | **False**       | **-3.69(...)7E-06 [23]** |  **49.857 ns** |   **0.8887 ns** |  **0.0487 ns** | **0.0081** |     **136 B** |
+| Construct_FromDoubleRounded                | False       | -3.69(...)7E-06 [23] |  62.215 ns |   1.8867 ns |  0.1034 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToEightDigits   | False       | -3.69(...)7E-06 [23] |  91.004 ns |  11.9486 ns |  0.6549 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | -3.69(...)7E-06 [23] | 101.314 ns |   3.9194 ns |  0.2148 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **0**                    |  **10.876 ns** |   **1.0251 ns** |  **0.0562 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | False       | 0                    |   4.136 ns |   0.2811 ns |  0.0154 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 0                    |   4.408 ns |   0.4593 ns |  0.0252 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 0                    |   4.377 ns |   0.4775 ns |  0.0262 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **0.022046226218487758** |  **37.736 ns** |   **3.2565 ns** |  **0.1785 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | False       | 0.022046226218487758 | 167.243 ns |  16.1363 ns |  0.8845 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 0.022046226218487758 |  92.050 ns |  20.7091 ns |  1.1351 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 0.022046226218487758 | 100.667 ns |   9.5603 ns |  0.5240 ns | 0.0038 |      64 B |
+| **Construct_FromDouble**                       | **False**       | **0.09999999999999999**  |  **38.369 ns** |   **0.9821 ns** |  **0.0538 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | False       | 0.09999999999999999  |   9.709 ns |   0.8487 ns |  0.0465 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 0.09999999999999999  |  46.287 ns |   2.7300 ns |  0.1496 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 0.09999999999999999  |  53.413 ns |   1.5931 ns |  0.0873 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **0.3333333333333333**   |  **37.196 ns** |   **2.8534 ns** |  **0.1564 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | False       | 0.3333333333333333   |   9.552 ns |   0.1119 ns |  0.0061 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 0.3333333333333333   |  85.045 ns |   7.7540 ns |  0.4250 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 0.3333333333333333   | 121.788 ns |  18.9315 ns |  1.0377 ns | 0.0038 |      64 B |
+| **Construct_FromDouble**                       | **False**       | **1.345**                |  **35.259 ns** |   **2.6987 ns** |  **0.1479 ns** | **0.0038** |      **64 B** |
+| Construct_FromDoubleRounded                | False       | 1.345                |  41.494 ns |   1.3521 ns |  0.0741 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 1.345                |  81.250 ns |   2.8159 ns |  0.1543 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 1.345                |  89.905 ns |   2.6632 ns |  0.1460 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **3.141592653589793**    |  **50.768 ns** |   **6.5910 ns** |  **0.3613 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | False       | 3.141592653589793    | 113.411 ns |   3.2945 ns |  0.1806 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 3.141592653589793    |  89.361 ns |   7.8277 ns |  0.4291 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 3.141592653589793    | 131.827 ns |   8.0933 ns |  0.4436 ns | 0.0076 |     128 B |
+| **Construct_FromDouble**                       | **False**       | **42**                   |  **50.918 ns** |   **2.8765 ns** |  **0.1577 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | False       | 42                   |   6.502 ns |   0.8178 ns |  0.0448 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 42                   |  33.300 ns |   0.6527 ns |  0.0358 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 42                   |  33.195 ns |   2.5218 ns |  0.1382 ns |      - |         - |
+| **Construct_FromDouble**                       | **False**       | **2110.11170524**        |  **51.168 ns** |   **8.8853 ns** |  **0.4870 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | False       | 2110.11170524        | 131.473 ns |   6.9116 ns |  0.3789 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 2110.11170524        |  78.427 ns |  11.2495 ns |  0.6166 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 2110.11170524        | 108.567 ns |   3.6905 ns |  0.2023 ns | 0.0038 |      64 B |
+| **Construct_FromDouble**                       | **False**       | **1024000000000**        |  **63.511 ns** |  **21.1784 ns** |  **1.1609 ns** | **0.0081** |     **136 B** |
+| Construct_FromDoubleRounded                | False       | 1024000000000        |   8.522 ns |   0.9506 ns |  0.0521 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 1024000000000        |  86.646 ns |  28.2179 ns |  1.5467 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 1024000000000        |  38.601 ns |   4.3756 ns |  0.2398 ns | 0.0019 |      32 B |
+| **Construct_FromDouble**                       | **False**       | **5.9722E+24**           |  **65.173 ns** |   **7.8373 ns** |  **0.4296 ns** | **0.0091** |     **152 B** |
+| Construct_FromDoubleRounded                | False       | 5.9722E+24           |   9.910 ns |   0.2508 ns |  0.0137 ns | 0.0024 |      40 B |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 5.9722E+24           | 110.220 ns |   1.0921 ns |  0.0599 ns | 0.0043 |      72 B |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 5.9722E+24           | 105.749 ns |   8.8746 ns |  0.4864 ns | 0.0043 |      72 B |
+| **Construct_FromDouble**                       | **False**       | **1.797(...)E+308 [23]** | **103.842 ns** |  **27.0670 ns** |  **1.4836 ns** | **0.0224** |     **376 B** |
+| Construct_FromDoubleRounded                | False       | 1.797(...)E+308 [23] |  10.899 ns |   3.9420 ns |  0.2161 ns | 0.0091 |     152 B |
+| Construct_FromDoubleRoundedToEightDigits   | False       | 1.797(...)E+308 [23] | 686.804 ns | 366.3354 ns | 20.0801 ns | 0.0181 |     304 B |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | 1.797(...)E+308 [23] | 711.889 ns | 501.6938 ns | 27.4995 ns | 0.0200 |     336 B |
+| **Construct_FromDouble**                       | **False**       | **Infinity**             |  **11.121 ns** |   **2.8776 ns** |  **0.1577 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | False       | Infinity             |   3.681 ns |   0.7684 ns |  0.0421 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | False       | Infinity             |   5.269 ns |  12.2797 ns |  0.6731 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | False       | Infinity             |   5.148 ns |   7.6119 ns |  0.4172 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **NaN**                  |  **11.021 ns** |   **0.3432 ns** |  **0.0188 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | True        | NaN                  |   4.014 ns |   0.0983 ns |  0.0054 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | NaN                  |   4.837 ns |   1.5692 ns |  0.0860 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | NaN                  |   4.693 ns |   0.1218 ns |  0.0067 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **-Infinity**            |  **10.926 ns** |   **1.2091 ns** |  **0.0663 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | True        | -Infinity            |   3.778 ns |   0.4835 ns |  0.0265 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | -Infinity            |   4.915 ns |   0.6273 ns |  0.0344 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | -Infinity            |   4.909 ns |   0.6648 ns |  0.0364 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **-7.92(...)4E+28 [22]** |  **99.874 ns** |   **6.3642 ns** |  **0.3488 ns** | **0.0081** |     **136 B** |
+| Construct_FromDoubleRounded                | True        | -7.92(...)4E+28 [22] |  12.392 ns |   3.3517 ns |  0.1837 ns | 0.0024 |      40 B |
+| Construct_FromDoubleRoundedToEightDigits   | True        | -7.92(...)4E+28 [22] | 118.043 ns |   3.1296 ns |  0.1715 ns | 0.0048 |      80 B |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | -7.92(...)4E+28 [22] | 125.181 ns |  18.1090 ns |  0.9926 ns | 0.0062 |     104 B |
+| **Construct_FromDouble**                       | **True**        | **-0.02702702702702703** | **117.074 ns** |  **13.9250 ns** |  **0.7633 ns** | **0.0114** |     **192 B** |
+| Construct_FromDoubleRounded                | True        | -0.02702702702702703 |  13.217 ns |   1.3698 ns |  0.0751 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | -0.02702702702702703 | 103.377 ns |  14.9742 ns |  0.8208 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | -0.02702702702702703 | 149.822 ns |  18.2927 ns |  1.0027 ns | 0.0038 |      64 B |
+| **Construct_FromDouble**                       | **True**        | **-3.69(...)7E-06 [23]** | **142.521 ns** |   **5.8304 ns** |  **0.3196 ns** | **0.0081** |     **136 B** |
+| Construct_FromDoubleRounded                | True        | -3.69(...)7E-06 [23] |  79.931 ns |   6.9924 ns |  0.3833 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToEightDigits   | True        | -3.69(...)7E-06 [23] | 107.807 ns |  12.6950 ns |  0.6959 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | -3.69(...)7E-06 [23] | 116.182 ns |  16.4465 ns |  0.9015 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **0**                    |  **11.149 ns** |   **0.1358 ns** |  **0.0074 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | True        | 0                    |   4.174 ns |   0.7106 ns |  0.0390 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 0                    |   4.384 ns |   0.2976 ns |  0.0163 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 0                    |   4.357 ns |   0.5986 ns |  0.0328 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **0.022046226218487758** | **210.895 ns** |   **6.9236 ns** |  **0.3795 ns** | **0.0095** |     **160 B** |
+| Construct_FromDoubleRounded                | True        | 0.022046226218487758 | 190.993 ns |   9.0919 ns |  0.4984 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 0.022046226218487758 | 144.508 ns |  21.0082 ns |  1.1515 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 0.022046226218487758 | 197.112 ns |  26.1490 ns |  1.4333 ns | 0.0076 |     128 B |
+| **Construct_FromDouble**                       | **True**        | **0.09999999999999999**  |  **83.477 ns** |   **0.6314 ns** |  **0.0346 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | True        | 0.09999999999999999  |  12.734 ns |   3.8391 ns |  0.2104 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 0.09999999999999999  |  53.287 ns |   1.9300 ns |  0.1058 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 0.09999999999999999  |  57.919 ns |   4.7757 ns |  0.2618 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **0.3333333333333333**   |  **75.709 ns** |   **2.6908 ns** |  **0.1475 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | True        | 0.3333333333333333   |  12.210 ns |   0.6933 ns |  0.0380 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 0.3333333333333333   |  95.932 ns |   4.6179 ns |  0.2531 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 0.3333333333333333   | 133.310 ns |  14.7550 ns |  0.8088 ns | 0.0038 |      64 B |
+| **Construct_FromDouble**                       | **True**        | **1.345**                | **105.032 ns** |   **9.3199 ns** |  **0.5109 ns** | **0.0038** |      **64 B** |
+| Construct_FromDoubleRounded                | True        | 1.345                |  55.110 ns |   2.7766 ns |  0.1522 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 1.345                | 114.019 ns |   6.0092 ns |  0.3294 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 1.345                | 121.056 ns |   6.6724 ns |  0.3657 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **3.141592653589793**    | **223.481 ns** |   **4.4057 ns** |  **0.2415 ns** | **0.0134** |     **224 B** |
+| Construct_FromDoubleRounded                | True        | 3.141592653589793    | 131.427 ns |  15.9316 ns |  0.8733 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 3.141592653589793    | 119.680 ns |   5.4861 ns |  0.3007 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 3.141592653589793    | 201.358 ns |  16.7724 ns |  0.9194 ns | 0.0076 |     128 B |
+| **Construct_FromDouble**                       | **True**        | **42**                   | **113.790 ns** |   **4.2476 ns** |  **0.2328 ns** | **0.0057** |      **96 B** |
+| Construct_FromDoubleRounded                | True        | 42                   |   7.716 ns |   0.9819 ns |  0.0538 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 42                   |  33.672 ns |   1.0068 ns |  0.0552 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 42                   |  33.891 ns |   7.3011 ns |  0.4002 ns |      - |         - |
+| **Construct_FromDouble**                       | **True**        | **2110.11170524**        | **175.691 ns** |  **16.6625 ns** |  **0.9133 ns** | **0.0095** |     **160 B** |
+| Construct_FromDoubleRounded                | True        | 2110.11170524        | 143.830 ns |  18.2601 ns |  1.0009 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 2110.11170524        |  99.134 ns |   8.8925 ns |  0.4874 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 2110.11170524        | 171.464 ns | 185.3595 ns | 10.1602 ns | 0.0057 |      96 B |
+| **Construct_FromDouble**                       | **True**        | **1024000000000**        | **151.023 ns** |  **12.1799 ns** |  **0.6676 ns** | **0.0114** |     **192 B** |
+| Construct_FromDoubleRounded                | True        | 1024000000000        |   9.787 ns |   3.4604 ns |  0.1897 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 1024000000000        |  87.719 ns |  13.8990 ns |  0.7619 ns | 0.0019 |      32 B |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 1024000000000        |  37.702 ns |   3.7138 ns |  0.2036 ns | 0.0019 |      32 B |
+| **Construct_FromDouble**                       | **True**        | **5.9722E+24**           | **220.440 ns** |  **14.7852 ns** |  **0.8104 ns** | **0.0134** |     **224 B** |
+| Construct_FromDoubleRounded                | True        | 5.9722E+24           |  11.477 ns |   1.3058 ns |  0.0716 ns | 0.0024 |      40 B |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 5.9722E+24           | 110.200 ns |  13.7255 ns |  0.7523 ns | 0.0043 |      72 B |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 5.9722E+24           | 106.414 ns |   8.0010 ns |  0.4386 ns | 0.0043 |      72 B |
+| **Construct_FromDouble**                       | **True**        | **1.797(...)E+308 [23]** | **359.894 ns** |  **57.0684 ns** |  **3.1281 ns** | **0.0334** |     **560 B** |
+| Construct_FromDoubleRounded                | True        | 1.797(...)E+308 [23] |  12.904 ns |   3.1300 ns |  0.1716 ns | 0.0091 |     152 B |
+| Construct_FromDoubleRoundedToEightDigits   | True        | 1.797(...)E+308 [23] | 672.669 ns | 296.0528 ns | 16.2277 ns | 0.0181 |     304 B |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | 1.797(...)E+308 [23] | 694.907 ns | 121.8652 ns |  6.6798 ns | 0.0200 |     336 B |
+| **Construct_FromDouble**                       | **True**        | **Infinity**             |  **10.963 ns** |   **0.9419 ns** |  **0.0516 ns** |      **-** |         **-** |
+| Construct_FromDoubleRounded                | True        | Infinity             |   3.622 ns |   0.2430 ns |  0.0133 ns |      - |         - |
+| Construct_FromDoubleRoundedToEightDigits   | True        | Infinity             |   4.715 ns |   0.5641 ns |  0.0309 ns |      - |         - |
+| Construct_FromDoubleRoundedToFifteenDigits | True        | Infinity             |   4.757 ns |   0.6608 ns |  0.0362 ns |      - |         - |

--- a/src/Fractions/Properties/Resources.Designer.cs
+++ b/src/Fractions/Properties/Resources.Designer.cs
@@ -88,38 +88,11 @@ namespace Fractions.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} shall be divided by zero..
+        ///   Looks up a localized string similar to The number of significant digits must be between 1 and 17 (inclusive)..
         /// </summary>
-        internal static string DivideByZero {
+        internal static string SignificantDigitsOutOfRange {
             get {
-                return ResourceManager.GetString("DivideByZero", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to NaN values are not supported..
-        /// </summary>
-        internal static string NaNNotSupported {
-            get {
-                return ResourceManager.GetString("NaNNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Negative infinity (-Infinity) is not supported..
-        /// </summary>
-        internal static string NegativeInfinityNotSupported {
-            get {
-                return ResourceManager.GetString("NegativeInfinityNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Positive infinity (+Infinity) is not supported..
-        /// </summary>
-        internal static string PositiveInfinityNotSupported {
-            get {
-                return ResourceManager.GetString("PositiveInfinityNotSupported", resourceCulture);
+                return ResourceManager.GetString("SignificantDigitsOutOfRange", resourceCulture);
             }
         }
         

--- a/src/Fractions/Properties/Resources.resx
+++ b/src/Fractions/Properties/Resources.resx
@@ -123,20 +123,11 @@
   <data name="CompareToArgumentException" xml:space="preserve">
     <value>The comparing instance must be of type {0}. The supplied argument is of type {1}</value>
   </data>
-  <data name="DivideByZero" xml:space="preserve">
-    <value>{0} shall be divided by zero.</value>
+  <data name="SignificantDigitsOutOfRange" xml:space="preserve">
+    <value>The number of significant digits must be between 1 and 17 (inclusive).</value>
   </data>
   <data name="TypeXnotSupported" xml:space="preserve">
     <value>The type {0} is not supported.</value>
-  </data>
-  <data name="NaNNotSupported" xml:space="preserve">
-    <value>NaN values are not supported.</value>
-  </data>
-  <data name="NegativeInfinityNotSupported" xml:space="preserve">
-    <value>Negative infinity (-Infinity) is not supported.</value>
-  </data>
-  <data name="PositiveInfinityNotSupported" xml:space="preserve">
-    <value>Positive infinity (+Infinity) is not supported.</value>
   </data>
   <data name="AccuracyIsLessThanOrEqualToZero" xml:space="preserve">
     <value>Accuracy of {0} is not allowed! Have to be above 0.</value>

--- a/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
+++ b/tests/Fractions.Tests/FractionSpecs/FromDoubleRounded/Method_FromDoubleRounded.cs
@@ -264,8 +264,8 @@ public class When_a_fractions_is_created_by_rounding_a_double_with_reasonable_nu
         new TestCaseData(-10.0, ReasonableNumberOfSignificantDigits).Returns(new Fraction(-10m)),
         new TestCaseData(0.1, ReasonableNumberOfSignificantDigits).Returns(new Fraction(0.1m)),
         new TestCaseData(-0.1, ReasonableNumberOfSignificantDigits).Returns(new Fraction(-0.1m)),
-        new TestCaseData(1055.05585262, 18).Returns(new Fraction(1055.05585262m)),
-        new TestCaseData(-1055.05585262, 18).Returns(new Fraction(-1055.05585262m))
+        new TestCaseData(1055.05585262, 17).Returns(new Fraction(1055.05585262m)),
+        new TestCaseData(-1055.05585262, 17).Returns(new Fraction(-1055.05585262m))
     ];
 
 
@@ -277,22 +277,28 @@ public class When_a_fractions_is_created_by_rounding_a_double_with_reasonable_nu
 }
 
 [TestFixture]
-public class When_a_fractions_is_created_by_rounding_a_double_with_exceeding_number_of_significant_digits : Spec {
+public class When_creating_a_fraction_by_rounding_a_double_with_more_than_17_significant_digits : Spec {
     private const double DoubleValue = 1055.05585262;
-    private const decimal LiteralValue = 1055.05585262m; // the "true/literal" decimal representation
 
     [Test]
-    public void The_fraction_preserves_the_rounding_error() {
-        Fraction.FromDoubleRounded(DoubleValue, 19).ToDecimal()
-            .Should().BeApproximately(LiteralValue, 0.0001m).And.NotBe(LiteralValue);
+    public void ArgumentOutOfRangeException_should_be_thrown() {
+        Invoking(() => Fraction.FromDoubleRounded(DoubleValue, 18)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+}
+
+[TestFixture]
+public class When_creating_a_fraction_by_rounding_a_double_with_less_than_1_significant_digits : Spec {
+    private const double DoubleValue = 1055.05585262;
+
+    [Test]
+    public void ArgumentOutOfRangeException_should_be_thrown() {
+        Invoking(() => Fraction.FromDoubleRounded(DoubleValue, 0)).Should().Throw<ArgumentOutOfRangeException>();
     }
 }
 
 [TestFixture]
 public class When_a_fractions_is_created_by_rounding_a_double_with_less_than_the_actual_significant_digits : Spec {
     private static IEnumerable<TestCaseData> TestCases { get; } = [
-        new TestCaseData(1055.05585262, 0).Returns(new Fraction(1000m)),
-        new TestCaseData(-1055.05585262, 0).Returns(new Fraction(-1000m)),
         new TestCaseData(1055.05585262, 1).Returns(new Fraction(1000m)),
         new TestCaseData(-1055.05585262, 1).Returns(new Fraction(-1000m)),
         new TestCaseData(1055.05585262, 2).Returns(new Fraction(1050m)),


### PR DESCRIPTION
- `ArgumentOutOfRangeException` is thrown when `significantDigits` is < 1 or > 17
- updating relevant tests
- updating the FromDoubleRoundedBenchmark (adding the `ReduceTerms` param)
- removed some obsolete Resources (`PositiveInfinityNotSupported` etc.)

This is actually a very important improvement (beyond the differences shown in the charts below) as in the previous implementation we get this:
<!DOCTYPE html>
<HTML>
<body>
<!--StartFragment-->

  | Name | Value | Type
-- | -- | -- | --
◢ | Fraction.FromDoubleRounded(1.2, 15, false) | {120000000000000/100000000000000} | Fractions.Fraction


<!--EndFragment-->
</body>
</HTML>

Which should now change to:
<!DOCTYPE html>
<HTML>
<body>
<!--StartFragment-->

  | Name | Value | Type
-- | -- | -- | --
◢ | Fraction.FromDoubleRounded(1.2, 15, false) | {12/10} | Fractions.Fraction
<!--EndFragment-->
</body>
</HTML>
