### PR TITLE
Switch to using PackageLicenseExpression and consolidate properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,29 @@
 ﻿<Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+
+    <Authors>Daniel Mueller</Authors>
+    <Copyright>Copyright 2013-2024 Daniel Mueller</Copyright>
+    <Version>8.0.3</Version>
+
+    <RepositoryUrl>https://github.com/danm-de/Fractions.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../Fractions.snk</AssemblyOriginatorKeyFile>
+
+    <PackageIcon>Fraction.png</PackageIcon>
+    <PackageIconUrl>https://raw.githubusercontent.com/danm-de/Fractions/master/src/Fractions/Fraction.ico</PackageIconUrl>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/danm-de/Fractions</PackageProjectUrl>
+    <PackageTags>fraction math</PackageTags>
+
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
 image: Visual Studio 2022
 build_script:
-  - cmd: dotnet build --configuration Release
+  - cmd: dotnet build --configuration Release -p:ContinuousIntegrationBuild=true
 test:
   assemblies:
     only:
       - '**\*.Tests.dll'
 test_script:
-  - dotnet test --configuration Release --no-build
+  - dotnet test --configuration Release --no-build --no-restore
 pull_requests:
   do_not_increment_build_number: true
 nuget:

--- a/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
+++ b/benchmarks/Fractions.Benchmarks/Fractions.Benchmarks.csproj
@@ -6,6 +6,7 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fractions.Json/Fractions.Json.csproj
+++ b/src/Fractions.Json/Fractions.Json.csproj
@@ -2,25 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
-    <Authors>Daniel Mueller</Authors>
     <Description>Converts a fraction data type to JSON by using Fraction's ToString() and FromString() methods. The class name is JsonFractionConverter.</Description>
-    <Copyright>Copyright 2013-2024 Daniel Mueller</Copyright>
-    <PackageProjectUrl>https://github.com/danm-de/Fractions</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/danm-de/Fractions/master/src/Fractions/Fraction.ico</PackageIconUrl>
-    <RepositoryUrl>https://github.com/danm-de/Fractions.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>fraction math</PackageTags>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>8.0.3</Version>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../Fractions.snk</AssemblyOriginatorKeyFile>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageIcon>Fraction.png</PackageIcon>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>Readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Fractions/Fractions.csproj
+++ b/src/Fractions/Fractions.csproj
@@ -3,27 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <Product>Fraction data type</Product>
-    <Authors>Daniel Mueller</Authors>
-    <Copyright>Copyright 2013-2024 Daniel Mueller</Copyright>
     <Title>Fraction data type</Title>
-    <PackageId>Fractions</PackageId>
-    <PackageProjectUrl>https://github.com/danm-de/Fractions</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/danm-de/Fractions/master/src/Fractions/Fraction.ico</PackageIconUrl>
-    <RepositoryUrl>https://github.com/danm-de/Fractions.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>fraction math</PackageTags>
     <Description>The fraction data type consists of two BigInteger values for numerator and denominator. It implements various operations (addition, subtraction, multiplication, division and remainder) with operator overloads.</Description>
-    <Version>8.0.3</Version>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../Fractions.snk</AssemblyOriginatorKeyFile>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageIcon>Fraction.png</PackageIcon>
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
-    <PackageReadmeFile>Readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
* PackageLicenseExpression will show up correctly on nuget.org and tools can analyze it
* moving common properties to shared Directory.Build.props fore easier maintenance

Now problems reported on [NuGet Package Explorer](https://nuget.info/packages/Fractions/8.0.3) are gone

![image](https://github.com/user-attachments/assets/20a49cdb-1587-4c7f-b3be-9db08dd99c90)
 