### PR TITLE
Adding a Fraction.Round overload with the "normalize" parameter

### DIFF
--- a/src/Fractions/Formatter/DecimalNotationFormatter.cs
+++ b/src/Fractions/Formatter/DecimalNotationFormatter.cs
@@ -932,7 +932,7 @@ public class DecimalNotationFormatter : ICustomFormatter {
     /// </returns>
     private static Fraction Round(Fraction x, int nbDigits,
         MidpointRounding midpointRounding = DefaultMidpointRoundingMode) {
-        return Fraction.Round(x, nbDigits, midpointRounding);
+        return Fraction.Round(x, nbDigits, midpointRounding, false);
     }
 
     /// <summary>

--- a/src/Fractions/Fraction.Constructors.cs
+++ b/src/Fractions/Fraction.Constructors.cs
@@ -42,9 +42,7 @@ public readonly partial struct Fraction {
     /// </summary>
     /// <param name="numerator">Numerator</param>
     /// <param name="denominator">Denominator</param>
-    /// <param name="normalize">If <c>true</c> the fraction will be created as reduced/simplified fraction. 
-    /// This is recommended, especially if your applications requires that the results of the equality methods <see cref="object.Equals(object)"/> 
-    /// and <see cref="IComparable.CompareTo"/> are always the same. (1/2 != 2/4)</param>
+    /// <param name="normalize">If <c>true</c> the fraction will be created as reduced/simplified fraction.</param>
     public Fraction(BigInteger numerator, BigInteger denominator, bool normalize) {
         if (normalize) {
             this = GetReducedFraction(numerator, denominator);


### PR DESCRIPTION
- when set to true- it ensures that the result is normalized (which wasn't always the case before)
- when set to false- it maintains the decimal denominator (and skipping the GCD reduction)
- the `DecimalNotationFormatter` now uses the non-normalized version (which is more performant)
- added the required tests in Method_Round