### PR TITLE
Remove Newtonsoft.Json dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 8.1.2
+
+- Fixed [#100](https://github.com/danm-de/Fractions/issues/100): Fractions 8.1.1 depends on Newtonsoft.Json (>= 13.0.3). Reported by [lipchev](https://github.com/lipchev)
+
 ## 8.1.1
 
 - Fixes [#93](https://github.com/danm-de/Fractions/issues/93): DecimalNotationFormatter throws FormatException for some custom formats (via [Pull-Request](https://github.com/danm-de/Fractions/pulls)) by [lipchev](https://github.com/lipchev)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,8 @@
     <LangVersion>latest</LangVersion>
 
     <Authors>Daniel Mueller</Authors>
-    <Copyright>Copyright 2013-2024 Daniel Mueller</Copyright>
-    <Version>8.1.1</Version>
+    <Copyright>Copyright 2013-2025 Daniel Mueller</Copyright>
+    <Version>8.1.2</Version>
 
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,4 @@
 image: Visual Studio 2022
-install:
-- ps: |
-    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
-    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '9.0.100' -InstallDir "$env:ProgramFiles\dotnet"
 build_script:
   - cmd: dotnet build --configuration Release -p:ContinuousIntegrationBuild=true
 test:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -50,7 +50,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fractions.Json/Fractions.Json.csproj
+++ b/src/Fractions.Json/Fractions.Json.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Fractions\Fractions.csproj" />
   </ItemGroup>
 

--- a/tests/Fractions.Json.Tests/Fractions.Json.Tests.csproj
+++ b/tests/Fractions.Json.Tests/Fractions.Json.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Fractions.Tests/FractionSpecs/TryParse/Method_TryParse.cs
+++ b/tests/Fractions.Tests/FractionSpecs/TryParse/Method_TryParse.cs
@@ -48,7 +48,7 @@ public class When_trying_to_parse_a_fraction {
         }
     }
 
-    private static CultureInfo _usEnglish = CultureInfo.GetCultureInfo("en_US");
+    private static CultureInfo _usEnglish = CultureInfo.GetCultureInfo("en-US");
 
     [Test, TestCaseSource(nameof(InvariantTestCases))]
     public void The_result_should_be_as_expected_when_using_Invariant_culture(string value, Fraction expected) {

--- a/tests/Fractions.Tests/Fractions.Tests.csproj
+++ b/tests/Fractions.Tests/Fractions.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0,8)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Fractions.Tests/Serialization/SystemTextJsonSerializationTests.cs
+++ b/tests/Fractions.Tests/Serialization/SystemTextJsonSerializationTests.cs
@@ -164,7 +164,7 @@ public class If_the_user_serializes_a_fraction_using_the_SystemTextJson_serializ
 public class
     If_the_user_serializes_a_fraction_using_the_SystemTextJson_serializer_with_StringFractionJsonConverter_and_US_English_culture {
     private static readonly JsonSerializerOptions _serializerOptions = new() {
-        Converters = { new StringFractionJsonConverter(CultureInfo.GetCultureInfo("en_US")) }
+        Converters = { new StringFractionJsonConverter(CultureInfo.GetCultureInfo("en-US")) }
     };
 
     private static IEnumerable<TestCaseData> SerializeTestCases {


### PR DESCRIPTION
Fixes [#100] 
Fractions 8.1.1 depends on Newtonsoft.Json (>= 13.0.3).
reported by lipchev (https://github.com/lipchev)