### PR TITLE
TryParse: replaced the usages of BigInteger.Power(TEN, exponent)

### DIFF
--- a/src/Fractions/Fraction.TryParse.cs
+++ b/src/Fractions/Fraction.TryParse.cs
@@ -711,7 +711,7 @@ public readonly partial struct Fraction {
 
         // 4. construct the fractional part using the corresponding decimal power for the denominator
         var nbDecimals = fractionalSpan.Length;
-        var denominator = BigInteger.Pow(TEN, nbDecimals);
+        var denominator = PowerOfTen(nbDecimals);
         fraction = reduceTerms ? ReduceSigned(numerator, denominator) : new Fraction(true, numerator, denominator);
         return true;
     }
@@ -1219,7 +1219,7 @@ public readonly partial struct Fraction {
         }
 
         // 4. construct the fractional part using the corresponding decimal power for the denominator
-        var denominator = BigInteger.Pow(TEN, nbDecimals);
+        var denominator = PowerOfTen(nbDecimals);
         fraction = reduceTerms ? ReduceSigned(numerator, denominator) : new Fraction(true, numerator, denominator);
         return true;
     }


### PR DESCRIPTION
- `TryParse`: replaced the usages of `BigInteger.Power(TEN, exponent)` with the `PowerOfTen` function